### PR TITLE
Added nodemanager service for adminVM and verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ env:
   git_token: ${{ secrets.GIT_TOKEN }}
   maxDynamicClusterSize: 2
   dynamicClusterSize: 1
-  wls_admin_services : "rngd wls_admin"
+  wls_admin_services : "rngd wls_admin wls_nodemanager"
   wls_managedServer_services : "rngd wls_nodemanager"
 
 jobs: 

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
@@ -118,6 +118,12 @@ domainInfo:
 topology:
    Name: "$wlsDomainName"
    AdminServerName: admin
+   Machine:
+     '$nmHost':
+         NodeManager:
+             ListenAddress: "$nmHost"
+             ListenPort: $nmPort
+             NMType : ssl
    Cluster:
         '$wlsClusterName':
             MigrationBasis: 'consensus'
@@ -636,7 +642,9 @@ then
   create_adminSetup
   admin_boot_setup
   create_adminserver_service
+  create_nodemanager_service
   enableAndStartAdminServerService
+  enabledAndStartNodeManagerService
   wait_for_admin  
 else
   updateNetworkRules "managed"


### PR DESCRIPTION
Resolution for Issue #117 Create and enable nodemanager service for dynamic cluster

- Created machine with nodemanager configurations and enabled services for adminVM

- Added verification for nodemanager service at adminVM

Trial run made and found working
https://github.com/sanjaymantoor/arm-oraclelinux-wls-dynamic-cluster/actions/runs/164385763