### PR TITLE
Add default value to addnode parameter adminUsername and fix parameters order in aadNestedTemplate.json

### DIFF
--- a/addnode/src/main/arm/mainTemplate.json
+++ b/addnode/src/main/arm/mainTemplate.json
@@ -42,6 +42,7 @@
       },
       "adminUsername": {
          "type": "string",
+         "defaultValue": "weblogic",
          "metadata": {
             "description": "User name for the Virtual Machine."
          }

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/aadNestedTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/aadNestedTemplate.json
@@ -53,6 +53,15 @@
                 "description": "Admin Server hosting VM name."
             }
         },
+        "dynamicClusterSize": {
+            "type": "int",
+            "defaultValue": 1,
+            "minValue": 1,
+            "maxValue": 100,
+            "metadata": {
+                "description": "Number of VMs hosting managed servers that have been deployed."
+            }
+        },
         "location": {
             "type": "string",
             "metadata": {
@@ -64,15 +73,6 @@
             "defaultValue": "msp",
             "metadata": {
                 "description": "Provide managed server prefix name"
-            }
-        },
-        "dynamicClusterSize": {
-            "type": "int",
-            "defaultValue": 1,
-            "minValue": 1,
-            "maxValue": 100,
-            "metadata": {
-                "description": "Number of VMs hosting managed servers that have been deployed."
             }
         },
         "wlsDomainName": {


### PR DESCRIPTION
Modified in addnode/src/main/arm/mainTemplate.json
Add default value to `adminUsername`.

Modified in arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/aadNestedTemplate.json
Fix parameters order