### PR TITLE
Enabling ssl port and SecurityConfiguration for admin server

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
@@ -135,6 +135,16 @@ topology:
                 CalculatedMachineNames: true
                 ServerNamePrefix: "${managedServerPrefix}"
                 MachineNameMatchExpression: "$machineNamePrefix-${vmNamePrefix}*"
+   Server:
+        '$wlsServerName':
+            ListenPort: $wlsAdminPort
+            RestartDelaySeconds: 10
+            SSL:
+                ListenPort: $wlsSSLAdminPort
+                Enabled: true	      
+   SecurityConfiguration:
+        NodeManagerUsername: "$wlsUserName"
+        NodeManagerPasswordEncrypted: "$wlsPassword"                
    ServerTemplate:
         '${dynamicServerTemplate}' :
             ListenPort: ${wlsManagedPort}


### PR DESCRIPTION
Resolution for [Enabling admin ssl port for dynamic cluster #150](https://github.com/wls-eng/arm-oraclelinux-wls/issues/150)

Dynamic cluster admin server is enabled with SSL port 7002.