### PR TITLE
fix-151-vm-size-limit-overly-restrictive

### DIFF
--- a/addnode/src/main/arm/mainTemplate.json
+++ b/addnode/src/main/arm/mainTemplate.json
@@ -130,14 +130,8 @@
       "vmSizeSelect": {
          "type": "string",
          "defaultValue": "Standard_A3",
-         "allowedValues": [
-            "Standard_A1",
-            "Standard_A2",
-            "Standard_A3",
-            "Standard_A4"
-         ],
          "metadata": {
-            "description": "Select appropriate VM Size as per requirement (Standard_A1, Standard_A2, Standard_A3, Standard_A4)"
+            "description": "Select appropriate VM Size as per requirement"
          }
       },
       "wlsDomainName": {

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -38,9 +38,33 @@
                 "visible": true
             },
             {
+                "name": "vmSizeSelect",
+                "type": "Microsoft.Compute.SizeSelector",
+                "label": "Virtual machine size",
+                "toolTip": "The size of virtual machine to provision.",
+                "recommendedSizes": [
+                    "Standard_A1",
+                    "Standard_A2",
+                    "Standard_A3",
+                    "Standard_A4",
+                    "Standard_B1ms"
+                ],
+                "constraints": {
+                    "excludedSizes": [
+                        "Standard_B1ls",
+                        "Standard_A0",
+                        "Basic_A0",
+                        "Standard_B1s"
+                    ]
+                },
+                "osPlatform": "Linux",
+                "count": "1",
+                "visible": true
+            },
+            {
                 "name": "basicsRequired",
                 "type": "Microsoft.Common.Section",
-                "label": "Credentails for Virtual Machines and WebLogic",
+                "label": "Credentials for Virtual Machines and WebLogic",
                 "elements": [
                     {
                         "name": "adminUsername",
@@ -195,22 +219,6 @@
                             "regex": "^[a-z0-9A-Z]{3,20}$",
                             "validationMessage": "The Domain Name must be between 3 and 20 characters long and contain letters, numbers only."
                         },
-                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
-                    },
-                    {
-                        "name": "vmSizeSelect",
-                        "type": "Microsoft.Compute.SizeSelector",
-                        "label": "Virtual machine size",
-                        "toolTip": "The size of virtual machine to provision.",
-                        "defaultValue": "Standard_A1",
-                        "recommendedSizes": [
-                            "Standard_A1",
-                            "Standard_A2",
-                            "Standard_A3",
-                            "Standard_A4"
-                        ],
-                        "osPlatform": "Linux",
-                        "count": "1",
                         "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
                     },
                     {
@@ -560,7 +568,7 @@
             "maxDynamicClusterSize": "[int(basics('basicsRequired').maxDynamicClusterSize)]",
             "portsToExpose": "[basics('basicsOptional').portsToExpose]",
             "skuUrnVersion": "[basics('skuUrnVersion')]",
-            "vmSizeSelect": "[basics('basicsOptional').vmSizeSelect]",
+            "vmSizeSelect": "[basics('vmSizeSelect')]",
             "wlsDomainName": "[basics('basicsOptional').wlsDomainName]",
             "wlsLDAPGroupBaseDN": "[steps('section_aad').aadInfo.wlsLDAPGroupBaseDN]",
             "wlsLDAPPrincipal": "[steps('section_aad').aadInfo.wlsLDAPPrincipal]",

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
@@ -169,14 +169,8 @@
         "vmSizeSelect": {
             "defaultValue": "Standard_A1",
             "type": "string",
-            "allowedValues": [
-                "Standard_A1",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_A4"
-            ],
             "metadata": {
-                "description": "Select appropriate VM Size as per requirement (Standard_A1, Standard_A2, Standard_A3, Standard_A4)"
+                "description": "Select appropriate VM Size as per requirement"
             }
         },
         "wlsDomainName": {

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -120,14 +120,8 @@
         "vmSizeSelect": {
             "type": "string",
             "defaultValue": "Standard_A3",
-            "allowedValues": [
-                "Standard_A1",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_A4"
-            ],
             "metadata": {
-                "description": "Select appropriate VM Size as per requirement (Standard_A1, Standard_A2, Standard_A3, Standard_A4)"
+                "description": "Select appropriate VM Size as per requirement"
             }
         },
         "wlsDomainName": {


### PR DESCRIPTION
Change summary:
- remove vm size restrictions
- move vmSizeSelect to required sections of basics
- add excluded vm sizes and another recommended vm size