### PR TITLE
Azure Applications: Validation message for WLS Admin password: no special characters

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -121,7 +121,7 @@
                         "constraints": {
                             "required": true,
                             "regex": "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d]{12,}$",
-                            "validationMessage": "The password must contain at least 12 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number."
+                            "validationMessage": "The password must contain at least 12 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number, and special characters are not allowed."
                         },
                         "options": {
                             "hideConfirmation": false


### PR DESCRIPTION
Modified in arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
Fix [Azure Applications: Validation message for WLS Admin password: no special characters](https://github.com/wls-eng/arm-oraclelinux-wls/issues/152)