### PR TITLE
Updating admin and nodemanager service for restart

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
@@ -418,7 +418,9 @@ function create_nodemanager_service()
  cat <<EOF >/etc/systemd/system/wls_nodemanager.service
  [Unit]
 Description=WebLogic nodemanager service
- 
+After=network-online.target
+Wants=network-online.target
+
 [Service]
 Type=simple
 # Note that the following three parameters should be changed to the correct paths
@@ -430,7 +432,9 @@ User=oracle
 Group=oracle
 KillMode=process
 LimitNOFILE=65535
- 
+Restart=always
+RestartSec=3
+
 [Install]
 WantedBy=multi-user.target
 EOF
@@ -444,7 +448,9 @@ function create_adminserver_service()
  cat <<EOF >/etc/systemd/system/wls_admin.service
 [Unit]
 Description=WebLogic Adminserver service
- 
+After=network-online.target
+Wants=network-online.target
+
 [Service]
 Type=simple
 WorkingDirectory="$DOMAIN_PATH/$wlsDomainName"
@@ -454,7 +460,9 @@ User=oracle
 Group=oracle
 KillMode=process
 LimitNOFILE=65535
- 
+Restart=always
+RestartSec=3
+
 [Install]
 WantedBy=multi-user.target
 EOF


### PR DESCRIPTION
Admin and nodemanager service is updated with
- network-online as prerequisite
- restart if service is failed

This fix is for the [Issue#160 : CI/CD test scenarios failing intermittently due to nodemanager service failure](https://github.com/wls-eng/arm-oraclelinux-wls/issues/160)

CI/CD tested and found working fine.
Refer https://github.com/sanjaymantoor/arm-oraclelinux-wls-dynamic-cluster/actions/runs/226949389