### PR TITLE
Adding NSG rules for NodeManager and Admin channel port

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -217,6 +217,32 @@
                             "direction": "Inbound",
                             "destinationPortRanges": "[split(concat(parameters('portsToExpose'),variables('const_requiredPortrange')), ',')]"
                         }
+                    },
+                    {
+                        "name": "WebLogicNMPort",
+                        "properties": {
+                            "protocol": "TCP",
+                            "sourcePortRange": "*",
+                            "sourceAddressPrefix": "Internet",
+                            "destinationAddressPrefix": "*",
+                            "access": "Deny",
+                            "priority": 201,
+                            "direction": "Inbound",
+                            "destinationPortRanges": [ "5556" ]
+                        }
+                    },
+                    {
+                        "name": "WebLogicAdminChannelPort",
+                        "properties": {
+                            "protocol": "TCP",
+                            "sourcePortRange": "*",
+                            "sourceAddressPrefix": "Internet",
+                            "destinationAddressPrefix": "*",
+                            "access": "Deny",
+                            "priority": 202,
+                            "direction": "Inbound",
+                            "destinationPortRanges": [ "7005" ]
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
This is first part of NSG rules implementation for the [Issue #58 Cluster Offers: Worker Nodes: make public/private IP configurable](https://github.com/wls-eng/arm-oraclelinux-wls/issues/58)

As part of this implementation WebLogic NodeManager and WebLogic Admin server channel ports , by default public access is denied.

CI/CD went fine, refer https://github.com/sanjaymantoor/arm-oraclelinux-wls-dynamic-cluster/actions/runs/277985776