### PR TITLE
specify internalDnsNameLabel

### DIFF
--- a/addnode/src/main/arm/mainTemplate.json
+++ b/addnode/src/main/arm/mainTemplate.json
@@ -297,7 +297,10 @@
                      }
                   }
                }
-            ]
+            ],
+            "dnsSettings": {
+               "internalDnsNameLabel": "[concat(variables('name_vmMachine'), copyIndex(parameters('numberOfExistingNodes')))]"
+            }
          }
       },
       {

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -328,7 +328,10 @@
                             }
                         }
                     }
-                ]
+                ],
+                "dnsSettings": {
+                    "internalDnsNameLabel": "[if(equals(copyIndex(),0),parameters('adminVMName'),concat(variables('const_managedVMPrefix'), copyIndex()))]"
+                }
             }
         },
         {


### PR DESCRIPTION
Fix intermittent deployment failure caused by hostname that appending with `internal.cloudapp.net` by Network Manager after machine restart.

Doc for [internalDnsNameLabel](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networkinterfaces)
![image](https://user-images.githubusercontent.com/59823457/96097546-ac99a100-0f03-11eb-9637-2443412fe152.png)
``` text
Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.
```