### PR TITLE
Coherence & CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -530,7 +530,7 @@ jobs:
           echo "query storage account name"
           storageAccount=$(az resource list -g $resourceGroup --resource-type Microsoft.Storage/storageAccounts --query [0].name -o tsv)
           echo "Storage account name: ${storageAccount}"
-          echo "##[set-env name=storageAccount;]${storageAccount}"
+          echo "storageAccount=${storageAccount}" >> $GITHUB_ENV
 
       - name: Set up Coherence by deploying sub template
         id: enable-coherence
@@ -625,7 +625,7 @@ jobs:
         run: |
           addnodeCoherenceVersion=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/pom.xml)
           artifactNameOfAddnodeCo=arm-oraclelinux-wls-dynamic-cluster-addnode-coherence-$addnodeCoherenceVersion-arm-assembly
-          echo "##[set-env name=artifactNameOfAddnodeCo;]${artifactNameOfAddnodeCo}"
+          echo "artifactNameOfAddnodeCo=${artifactNameOfAddnodeCo}" >> $GITHUB_ENV
           echo "##[set-output name=artifactNameOfAddnodeCo;]${artifactNameOfAddnodeCo}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
           name: ${{steps.addnode_artifact_file.outputs.addnode_artifactName}}
           path: ${{steps.addnode_artifact_path.outputs.addnode_artifactPath}}
 
-      - name: Archive arm-oraclelinux-wls-cluster addnode template
+      - name: Archive arm-oraclelinux-wls-dynamic-cluster addnode template
         uses: actions/upload-artifact@v1
         if: success()
         with:
@@ -183,6 +183,22 @@ jobs:
         with:
           name: ${{steps.deletenode_artifact_file.outputs.deletenode_artifactName}}
           path: ${{steps.deletenode_artifact_file.outputs.deletenode_artifactPath}}
+
+      - name: Generate addnode-coherence artifact file name and path
+        id: addnode_coherence_artifact_file
+        run: |
+          addnode_coherence_version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/pom.xml)
+          addnode_coherence_artifactName=arm-oraclelinux-wls-dynamic-cluster-addnode-coherence-$addnode_coherence_version-arm-assembly
+          unzip arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/target/$addnode_coherence_artifactName.zip -d arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/target/$addnode_coherence_artifactName
+          echo "##[set-output name=addnode_coherence_artifactName;]${addnode_coherence_artifactName}"
+          echo "##[set-output name=addnode_coherence_artifactPath;]arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/target/$addnode_coherence_artifactName"
+
+      - name: Archive arm-oraclelinux-wls-dynamic-cluster addnode-coherence template
+        uses: actions/upload-artifact@v1
+        if: success()
+        with:
+          name: ${{steps.addnode_coherence_artifact_file.outputs.addnode_coherence_artifactName}}
+          path: ${{steps.addnode_coherence_artifact_file.outputs.addnode_coherence_artifactPath}}
 
   deploy-dependencies:
     needs: preflight
@@ -508,6 +524,43 @@ jobs:
             --parameters @arm-oraclelinux-wls-dynamic-cluster/test/scripts/parameters-deploy-elk.json \
             --template-file ${artifactName}/nestedtemplates/elkNestedTemplate.json
 
+      - name: Get storage account name
+        id: query-storage-account-name
+        run: |
+          echo "query storage account name"
+          storageAccount=$(az resource list -g $resourceGroup --resource-type Microsoft.Storage/storageAccounts --query [0].name -o tsv)
+          echo "Storage account name: ${storageAccount}"
+          echo "##[set-env name=storageAccount;]${storageAccount}"
+
+      - name: Set up Coherence by deploying sub template
+        id: enable-coherence
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            # Generate parameters for Coherence template deployment
+            bash arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-coherence.sh \
+            arm-oraclelinux-wls-dynamic-cluster/test/scripts/parameters-deploy-coherence.json \
+            ${{ env.adminVMName }} \
+            ${{ env.wlsPassword }} \
+            "${{ matrix.images }}" \
+            ${{ env.location }} \
+            ${storageAccount} \
+            ${{ env.wlsDomainName }} \
+            ${{ env.wlsUserName }} \
+            ${{ env.wlsPassword }} \
+            ${{ env.userName }} \
+            ${{ env.testbranchName }} \
+            ${{ env.managedServerPrefix }}
+
+            echo "Deploy Coherence Template..."
+            az group deployment create \
+            --debug \
+            --resource-group ${resourceGroup} \
+            --name coherence \
+            --parameters @arm-oraclelinux-wls-dynamic-cluster/test/scripts/parameters-deploy-coherence.json \
+            --template-file ${artifactName}/nestedtemplates/coherenceTemplate.json
+
       - name: Output addnode artifact name
         id: artifact_file_addnode
         run: |
@@ -526,17 +579,14 @@ jobs:
         with:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |
-            echo "add two new nodes and enable app gateway"
-            echo "query storage account name"
-            storageAccount=$(az resource list -g $resourceGroup --resource-type Microsoft.Storage/storageAccounts --query [0].name -o tsv)
-            echo "Storage account name: ${storageAccount}"
+            echo "add two new nodes"
             echo "generate add-node parameters"
             bash arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-addnode.sh \
             arm-oraclelinux-wls-dynamic-cluster/test/scripts/parameters-deploy-addnode.json \
               ${{ env.wlsPassword }} \
               ${{ env.adminVMName }}:7001 \
               weblogic \
-              2 \
+              1 \
               "${{ matrix.images }}" \
               ${storageAccount} \
               ${{ env.wlsDomainName }} \
@@ -567,6 +617,62 @@ jobs:
           mspVM2=$(az resource list -g ${resourceGroup} --resource-type Microsoft.Compute/virtualMachines --name ${{ env.managedServerPrefix }}VM2 --query [0].name -o tsv)
           if [ -z "$mspVM2" ]; then
             echo "Add-node failure: new machine ${{ env.managedServerPrefix }}VM2 does not exist."
+            exit 1
+          fi
+
+      - name: Output addnode-coherence artifact name
+        id: artifact_file_addnode_coherence
+        run: |
+          addnodeCoherenceVersion=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/pom.xml)
+          artifactNameOfAddnodeCo=arm-oraclelinux-wls-dynamic-cluster-addnode-coherence-$addnodeCoherenceVersion-arm-assembly
+          echo "##[set-env name=artifactNameOfAddnodeCo;]${artifactNameOfAddnodeCo}"
+          echo "##[set-output name=artifactNameOfAddnodeCo;]${artifactNameOfAddnodeCo}"
+      - name: Download artifact for deployment
+        uses: actions/download-artifact@v1
+        with:
+          name: ${{steps.artifact_file_addnode_coherence.outputs.artifactNameOfAddnodeCo}}
+
+      - name: Add new cache node to coherence cluster
+        id: add-node-coherence
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            echo "add new cache server"
+            echo "generate parameters"
+            bash arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-addnode-coherence.sh \
+            arm-oraclelinux-wls-dynamic-cluster/test/scripts/parameters-deploy-addnode-coherence.json \
+              ${{ env.wlsPassword }} \
+              ${{ env.adminVMName }} \
+              weblogic \
+              1 \
+              "${{ matrix.images }}" \
+              ${storageAccount} \
+              ${{ env.wlsDomainName }} \
+              ${{ env.location }} \
+              ${{ env.wlsUserName }} \
+              ${{ env.wlsPassword }} \
+              ${{ env.userName }} \
+              ${{ env.testbranchName }} \
+              ${{ env.managedServerPrefix }}
+            echo "deploy add-node template to create new nodes"
+            az group deployment validate \
+              -g ${resourceGroup} \
+              -f ${artifactNameOfAddnodeCo}/mainTemplate.json \
+              -p @arm-oraclelinux-wls-dynamic-cluster/test/scripts/parameters-deploy-addnode-coherence.json \
+              --no-prompt
+            az group deployment create \
+              --debug \
+              --resource-group ${resourceGroup} \
+              --name addnode \
+              --parameters @arm-oraclelinux-wls-dynamic-cluster/test/scripts/parameters-deploy-addnode-coherence.json \
+              --template-file ${artifactNameOfAddnodeCo}/mainTemplate.json
+      - name: Verify new nodes
+        id: verify-new-nodes-coherence
+        run: |
+          mspVM2=$(az resource list -g ${resourceGroup} --resource-type Microsoft.Compute/virtualMachines --name ${{ env.managedServerPrefix }}StorageVM2 --query [0].name -o tsv)
+          if [ -z "$mspVM2" ]; then
+            echo "Add-node failure: new machine ${{ env.managedServerPrefix }}StorageVM2 does not exist."
             exit 1
           fi
 

--- a/addnode-coherence/pom.xml
+++ b/addnode-coherence/pom.xml
@@ -25,35 +25,28 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.oracle.weblogic.azure</groupId>
-    <artifactId>arm-oraclelinux-wls-dynamic-cluster-root</artifactId>
-    <packaging>pom</packaging>
-    <version>1.0.8</version>
+    <artifactId>arm-oraclelinux-wls-dynamic-cluster-addnode-coherence</artifactId>
+    <version>1.0.0</version>
+    
+    <parent>
+        <groupId>com.microsoft.azure.iaas</groupId>
+        <artifactId>azure-javaee-iaas-parent</artifactId>
+        <version>1.0.6</version>
+        <relativePath></relativePath>
+    </parent>
+    
+    <packaging>jar</packaging>
     <name>${project.artifactId}</name>
+
+    <properties>
+        <template.validation.tests.directory>${basedir}/../../arm-ttk/arm-ttk</template.validation.tests.directory>
+        <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;addnode-coherence/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-dynamic-cluster/${git.tag}/&quot;}'</test.parameters>
+        <template.pid.properties.url>https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls/develop/src/main/resources/pid.properties</template.pid.properties.url>
+        <template.microsoft.pid.properties.url>https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls/develop/src/main/resources/microsoft-pid.properties</template.microsoft.pid.properties.url>
+    </properties>
+
     <description>
         
     </description>
-    <url>https://github.com/wls-eng/arm-oraclelinux-wls-dynamic-cluster</url>
-
-    <scm>
-        <connection>scm:git:git@github.com:wls-eng/arm-oraclelinux-wls-dynamic-cluster.git</connection>
-        <developerConnection>scm:git:git@github.com:wls-eng/arm-oraclelinux-wls-dynamic-cluster.git</developerConnection>
-        <url>https://github.com/wls-eng/arm-oraclelinux-wls-dynamic-cluster</url>
-        <tag>HEAD</tag>
-    </scm>
-    
-    <licenses>
-        <license>
-            <name>Apache 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <modules>
-      <module>addnode</module>
-      <module>addnode-coherence</module>
-      <module>deletenode</module>
-      <module>arm-oraclelinux-wls-dynamic-cluster</module>
-    </modules>
 
 </project>

--- a/addnode-coherence/src/main/arm/addnodedeploy.parameters.json
+++ b/addnode-coherence/src/main/arm/addnodedeploy.parameters.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
+    },
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminVMName": {
+      "value": "GEN-UNIQUE"
+    },
+    "dnsLabelPrefix": {
+      "value": "GEN-UNIQUE"
+    },
+    "numberOfExistingCacheNodes": {
+      "value": 1
+    },
+    "numberOfNewCacheNodes": {
+      "value": 1
+    },
+    "skuUrnVersion": {
+      "value": "GEN-UNIQUE"
+    },
+    "storageAccountName": {
+      "value": "GEN-UNIQUE"
+    },
+    "usePreviewImage": {
+      "value": "GEN-UNIQUE"
+    },
+    "vmSizeSelectForCoherence": {
+      "value": "GEN-UNIQUE"
+    },
+    "wlsDomainName": {
+      "value": "GEN-UNIQUE"
+    },
+    "wlsPassword": {
+      "value": "GEN-UNIQUE"
+    },
+    "wlsUserName": {
+      "value": "GEN-UNIQUE"
+    }
+  }
+}

--- a/addnode-coherence/src/main/arm/mainTemplate.json
+++ b/addnode-coherence/src/main/arm/mainTemplate.json
@@ -54,6 +54,27 @@
                 "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
             }
         },
+        "elkSettings": {
+            "type": "object",
+            "defaultValue": {
+                "enable": false,
+                "elasticsearchEndpoint": "null",
+                "elasticsearchPassword": "null",
+                "elasticsearchUserName": "null",
+                "logIndex": "null",
+                "logsToIntegrate": [ "HTTPAccessLog", "ServerLog", "DomainLog", "DataSourceLog", "StandardErrorAndOutput", "NodeManagerLog" ]
+            },
+            "metadata": {
+                "description": "If enable is true, must specify all the properties of elkSettings. logsToIntegrate must be value of an array."
+            }
+        },
+        "enableCoherenceWebLocalStorage": {
+            "defaultValue": true,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether Local Storage is enabled for the Coherence*Web cluster tier."
+            }
+        },
         "guidValue": {
             "type": "string",
             "defaultValue": "[newGuid()]"
@@ -169,7 +190,8 @@
         "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
         "name_nic": "_NIC",
         "name_publicIPAddress": "_PublicIP",
-        "name_scriptFile": "setupCoherence.sh",
+        "name_scriptCoherenceFile": "setupCoherence.sh",
+        "name_scriptELKConfiguration": "elkIntegrationForConfiguredCluster.sh",
         "name_share": "wlsshare",
         "name_subnet": "Subnet",
         "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
@@ -177,6 +199,25 @@
         "name_wlsServerPrefix": "[concat(parameters('managedServerPrefix'),'Storage')]",
         "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]"
     },
+    "functions": [
+        {
+            "namespace": "array",
+            "members": {
+                "join": {
+                    "parameters": [
+                        {
+                            "name": "items",
+                            "type": "array"
+                        }
+                    ],
+                    "output": {
+                        "type": "string",
+                        "value": "[replace(replace(replace(string(parameters('items')), '[\"', ''), '\"]', ''), '\",\"', ',')]"
+                    }
+                }
+            }
+        }
+    ],
     "resources": [
         {
             "apiVersion": "${azure.apiVersion}",
@@ -302,7 +343,7 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": true,
-                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '2019-06-01').primaryEndpoints.blob]"
+                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '${azure.apiVersion2}').primaryEndpoints.blob]"
                     }
                 }
             },
@@ -331,11 +372,12 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "fileUris": [
-                        "[uri(parameters('_artifactsLocation'), concat('../../../arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/', variables('name_scriptFile'), parameters('_artifactsLocationSasToken')))]"
+                        "[uri(parameters('_artifactsLocation'), concat('../../../arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/', variables('name_scriptCoherenceFile'), parameters('_artifactsLocationSasToken')))]",
+                        "[uri(parameters('_artifactsLocation'), concat('../../../arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/', variables('name_scriptELKConfiguration'), parameters('_artifactsLocationSasToken')))]"
                     ]
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'), ' ', parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',concat(variables('name_wlsServerPrefix'),copyIndex(variables('const_cacheServerIndexOffset'))),' ', parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', 'true')]"
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptCoherenceFile'), ' ', parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', parameters('enableCoherenceWebLocalStorage'),' ',parameters('elkSettings').enable, ' ',parameters('elkSettings').elasticsearchEndpoint,' ', parameters('elkSettings').elasticsearchUserName,' ', parameters('elkSettings').elasticsearchPassword, ' ', array.join(parameters('elkSettings').logsToIntegrate), ' ',parameters('elkSettings').logIndex, ' ',variables('name_wlsServerPrefix'),' ',copyIndex(variables('const_cacheServerIndexOffset')))]"
                 }
             }
         },

--- a/addnode-coherence/src/main/arm/mainTemplate.json
+++ b/addnode-coherence/src/main/arm/mainTemplate.json
@@ -1,0 +1,366 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "_artifactsLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+            },
+            "defaultValue": "${artifactsLocationBase}/arm-oraclelinux-wls-dynamic-cluster/${git.tag}/addnode-coherence/src/main/"
+        },
+        "_artifactsLocationSasToken": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured."
+            },
+            "defaultValue": ""
+        },
+        "adminPasswordOrKey": {
+            "type": "securestring",
+            "metadata": {
+                "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "defaultValue": "weblogic",
+            "metadata": {
+                "description": "User name for the Virtual Machine."
+            }
+        },
+        "adminVMName": {
+            "defaultValue": "adminVM",
+            "type": "string",
+            "metadata": {
+                "description": "Admin Server hosting VM name."
+            }
+        },
+        "authenticationType": {
+            "type": "string",
+            "defaultValue": "password",
+            "allowedValues": [
+                "sshPublicKey",
+                "password"
+            ],
+            "metadata": {
+                "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+            }
+        },
+        "dnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "wls",
+            "metadata": {
+                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "guidValue": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "managedServerPrefix": {
+            "type": "string",
+            "defaultValue": "msp",
+            "metadata": {
+                "description": "Provide managed server prefix name"
+            }
+        },
+        "numberOfExistingCacheNodes": {
+            "type": "int",
+            "defaultValue": 1,
+            "minValue": 1,
+            "maxValue": 20,
+            "metadata": {
+                "description": "Number of existing Coherence cache servers, used to name new Virtual Machines and new Managed Server for cache."
+            }
+        },
+        "numberOfNewCacheNodes": {
+            "type": "int",
+            "defaultValue": 1,
+            "minValue": 1,
+            "maxValue": 20,
+            "metadata": {
+                "description": "Number of new Coherence cahce servers, used to create Virtual Machines and Managed Server for cache."
+            }
+        },
+        "skuUrnVersion": {
+            "type": "string",
+            "defaultValue": "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;latest",
+            "allowedValues": [
+                "owls-122130-8u131-ol73;Oracle:weblogic-122130-jdk8u131-ol73:owls-122130-8u131-ol7;latest",
+                "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;latest",
+                "owls-122140-8u251-ol76;Oracle:weblogic-122140-jdk8u251-ol76:owls-122140-8u251-ol7;latest",
+                "owls-141100-8u251-ol76;Oracle:weblogic-141100-jdk8u251-ol76:owls-141100-8u251-ol7;latest",
+                "owls-141100-11_07-ol76;Oracle:weblogic-141100-jdk11_07-ol76:owls-141100-11_07-ol7;latest"
+            ],
+            "metadata": {
+                "description": "The Oracle Linux image with Weblogic and Java preinstalled. Semicolon separated string of Sku, URN, and Version"
+            }
+        },
+        "storageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of storage account. One storage account can store 20 vitual machines with 2 VHDs of 500 IOPS."
+            }
+        },
+        "usePreviewImage": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Bool value, if it's set to true, will deploy with preview weblogic image."
+            }
+        },
+        "vmSizeSelectForCoherence": {
+            "defaultValue": "Standard_A3",
+            "type": "string",
+            "metadata": {
+                "description": "Select appropriate VM Size for Coherence"
+            }
+        },
+        "wlsDomainName": {
+            "type": "string",
+            "defaultValue": "wlsd",
+            "metadata": {
+                "description": "Provide Weblogic domain name"
+            }
+        },
+        "wlsPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for your Weblogic domain name"
+            }
+        },
+        "wlsUserName": {
+            "defaultValue": "weblogic",
+            "type": "string",
+            "metadata": {
+                "description": "Username for your Weblogic domain name"
+            }
+        }
+    },
+    "variables": {
+        "const_cacheServerIndexOffset": "[add(parameters('numberOfExistingCacheNodes'), 1)]",
+        "const_hyphen": "-",
+        "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),'jdk',split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
+        "const_imagePublisher": "oracle",
+        "const_linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                        "keyData": "[parameters('adminPasswordOrKey')]"
+                    }
+                ]
+            }
+        },
+        "const_mountPointPath": "[concat('/mnt/', variables('name_share'))]",
+        "const_publicIPAddressType": "Dynamic",
+        "const_vmSize": "[parameters('vmSizeSelectForCoherence')]",
+        "const_wlsDomainPath": "/u01/domains",
+        "const_wlsHome": "/u01/app/wls/install/oracle/middleware/oracle_home",
+        "name_linuxImageOfferSKU": "[first(split(parameters('skuUrnVersion'), ';'))]",
+        "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
+        "name_nic": "_NIC",
+        "name_publicIPAddress": "_PublicIP",
+        "name_scriptFile": "setupCoherence.sh",
+        "name_share": "wlsshare",
+        "name_subnet": "Subnet",
+        "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+        "name_vmMachine": "[concat(parameters('managedServerPrefix'),'StorageVM')]",
+        "name_wlsServerPrefix": "[concat(parameters('managedServerPrefix'),'Storage')]",
+        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]"
+    },
+    "resources": [
+        {
+            "apiVersion": "${azure.apiVersion}",
+            "name": "${dynamic.addnode.coherence.start}",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_vmMachine'),copyIndex(variables('const_cacheServerIndexOffset')),variables('name_publicIPAddress'))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "publicIPLoop",
+                "count": "[parameters('numberOfNewCacheNodes')]"
+            },
+            "properties": {
+                "publicIPAllocationMethod": "[variables('const_publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[concat(toLower(parameters('dnsLabelPrefix')),copyindex(variables('const_cacheServerIndexOffset')),'-',take(replace(parameters('guidValue'),'-',''),10),'-',toLower(parameters('wlsDomainName')))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_virtualNetwork'), '/', variables('name_subnet'))]",
+            "condition": "[and(empty(variables('name_virtualNetwork')), empty(variables('name_subnet')))]"
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_vmMachine'), copyIndex(variables('const_cacheServerIndexOffset')), variables('name_nic'))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "nicLoop",
+                "count": "[parameters('numberOfNewCacheNodes')]"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(variables('name_vmMachine'),copyIndex(variables('const_cacheServerIndexOffset')),variables('name_publicIPAddress')))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat(variables('name_vmMachine'),copyIndex(variables('const_cacheServerIndexOffset')),variables('name_publicIPAddress')))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ],
+                "dnsSettings": {
+                    "internalDnsNameLabel": "[concat(variables('name_vmMachine'), copyIndex(variables('const_cacheServerIndexOffset')))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_vmMachine'), copyIndex(variables('const_cacheServerIndexOffset')))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[parameters('numberOfNewCacheNodes')]"
+            },
+            "dependsOn": [
+                "nicLoop"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('const_vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('name_vmMachine'), copyIndex(variables('const_cacheServerIndexOffset')))]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPasswordOrKey')]",
+                    "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('const_imagePublisher')]",
+                        "offer": "[variables('const_imageOffer')]",
+                        "sku": "[variables('name_linuxImageOfferSKU')]",
+                        "version": "[variables('name_linuxImageVersion')]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "Standard_LRS"
+                        }
+                    },
+                    "dataDisks": [
+                        {
+                            "lun": 0,
+                            "createOption": "FromImage",
+                            "diskSizeGB": 900,
+                            "managedDisk": {
+                                "storageAccountType": "Standard_LRS"
+                            }
+                        }
+                    ]
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('name_vmMachine'), copyIndex(variables('const_cacheServerIndexOffset')), variables('name_nic')))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true,
+                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '2019-06-01').primaryEndpoints.blob]"
+                    }
+                }
+            },
+            "plan": {
+                "name": "[variables('name_linuxImageOfferSKU')]",
+                "publisher": "[variables('const_imagePublisher')]",
+                "product": "[variables('const_imageOffer')]"
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(variables('name_vmMachine'), copyIndex(variables('const_cacheServerIndexOffset')),'/newuserscript')]",
+            "apiVersion": "${azure.apiVersion}",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "virtualMachineExtensionLoop",
+                "count": "[parameters('numberOfNewCacheNodes')]"
+            },
+            "dependsOn": [
+                "virtualMachineLoop"
+            ],
+            "properties": {
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "fileUris": [
+                        "[uri(parameters('_artifactsLocation'), concat('../../../arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/', variables('name_scriptFile'), parameters('_artifactsLocationSasToken')))]"
+                    ]
+                },
+                "protectedSettings": {
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'), ' ', parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',concat(variables('name_wlsServerPrefix'),copyIndex(variables('const_cacheServerIndexOffset'))),' ', parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', 'true')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "${azure.apiVersion}",
+            "name": "${dynamic.addnode.coherence.end}",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "virtualMachineExtensionLoop"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "artifactsLocationPassedIn": {
+            "type": "string",
+            "value": "[parameters('_artifactsLocation')]"
+        }
+    }
+}

--- a/addnode/src/main/arm/mainTemplate.json
+++ b/addnode/src/main/arm/mainTemplate.json
@@ -76,9 +76,8 @@
          "type": "object",
          "defaultValue": {
             "enable": false,
+            "elasticsearchEndpoint": "null",
             "elasticsearchPassword": "null",
-            "elasticsearchPort": "null",
-            "elasticsearchURI": "null",
             "elasticsearchUserName": "null",
             "logIndex": "null",
             "logsToIntegrate": [ "HTTPAccessLog", "ServerLog", "DomainLog", "DataSourceLog", "StandardErrorAndOutput", "NodeManagerLog" ]
@@ -209,7 +208,7 @@
       "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
       "name_nic": "_NIC",
       "name_publicIPAddress": "_PublicIP",
-      "name_scriptELKConfiguration": "elkIntegration.sh",
+      "name_scriptELKConfiguration": "elkIntegrationForDynamicCluster.sh",
       "name_scriptFile": "addNodeToDynamicCluster.sh",
       "name_share": "wlsshare",
       "name_subnet": "Subnet",
@@ -360,7 +359,7 @@
             "diagnosticsProfile": {
                "bootDiagnostics": {
                   "enabled": true,
-                  "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '2019-06-01').primaryEndpoints.blob]"
+                  "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '${azure.apiVersion2}').primaryEndpoints.blob]"
                }
             }
          },
@@ -394,7 +393,7 @@
                ]
             },
             "protectedSettings": {
-               "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' ',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('managedServerPrefix'),' ',copyIndex(variables('const_appNodeMachineOffset')),' ', parameters('adminURL'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('dynamicClusterSize'),' ', variables('const_managedVMPrefix'),' ',parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').certificateBase64String, 'null'),' ',if(parameters('aadsSettings').enable, parameters('aadsSettings').publicIP, 'null'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').serverHost, 'null'),' ', parameters('adminPasswordOrKey'), ' ',parameters('elkSettings').enable,' ', concat(parameters('elkSettings').elasticsearchURI,':',parameters('elkSettings').elasticsearchPort),' ', parameters('elkSettings').elasticsearchUserName,' ', parameters('elkSettings').elasticsearchPassword,' ', array.join(parameters('elkSettings').logsToIntegrate), ' ', parameters('elkSettings').logIndex, ' ', parameters('maxDynamicClusterSize'))]"
+               "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' ',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('managedServerPrefix'),' ',copyIndex(variables('const_appNodeMachineOffset')),' ', parameters('adminURL'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('dynamicClusterSize'),' ', variables('const_managedVMPrefix'),' ',parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').certificateBase64String, 'null'),' ',if(parameters('aadsSettings').enable, parameters('aadsSettings').publicIP, 'null'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').serverHost, 'null'),' ', parameters('adminPasswordOrKey'), ' ',parameters('elkSettings').enable,' ', parameters('elkSettings').elasticsearchEndpoint,' ', parameters('elkSettings').elasticsearchUserName,' ', parameters('elkSettings').elasticsearchPassword,' ', array.join(parameters('elkSettings').logsToIntegrate), ' ', parameters('elkSettings').logIndex, ' ', parameters('maxDynamicClusterSize'))]"
             }
          }
       },

--- a/addnode/src/main/arm/mainTemplate.json
+++ b/addnode/src/main/arm/mainTemplate.json
@@ -109,7 +109,7 @@
          "defaultValue": 10,
          "type": "int",
          "metadata": {
-            "description": "Maximum Number of Managed Servers allowed to be configured in the Dynamic Cluster."
+            "description": "Maximum number of Managed Servers allowed to be configured in the Dynamic Cluster."
          }
       },
       "numberOfExistingNodes": {
@@ -117,7 +117,7 @@
          "minValue": 1,
          "maxValue": 20,
          "metadata": {
-            "description": "The number of existing nodes, used to generate new managed server virtual machine name, including Admin Server Node."
+            "description": "The number of existing vitural machines that host aplication managed servers, used to generate new virtual machine name."
          }
       },
       "numberOfNewNodes": {
@@ -126,7 +126,7 @@
          "minValue": 1,
          "maxValue": 20,
          "metadata": {
-            "description": "The number of nodes to add."
+            "description": "The number of new machine to add."
          }
       },
       "skuUrnVersion": {
@@ -184,6 +184,7 @@
       }
    },
    "variables": {
+      "const_appNodeMachineOffset": "[add(parameters('numberOfExistingNodes'), 1)]",
       "const_hyphen": "-",
       "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),'jdk',split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
       "const_imagePublisher": "oracle",
@@ -252,7 +253,7 @@
       {
          "type": "Microsoft.Network/publicIPAddresses",
          "apiVersion": "${azure.apiVersion}",
-         "name": "[concat(variables('name_vmMachine'),copyIndex(parameters('numberOfExistingNodes')),variables('name_publicIPAddress'))]",
+         "name": "[concat(variables('name_vmMachine'),copyIndex(variables('const_appNodeMachineOffset')),variables('name_publicIPAddress'))]",
          "location": "[parameters('location')]",
          "copy": {
             "name": "publicIPLoop",
@@ -274,14 +275,14 @@
       {
          "type": "Microsoft.Network/networkInterfaces",
          "apiVersion": "${azure.apiVersion}",
-         "name": "[concat(variables('name_vmMachine'),copyIndex(parameters('numberOfExistingNodes')), variables('name_nic'))]",
+         "name": "[concat(variables('name_vmMachine'),copyIndex(variables('const_appNodeMachineOffset')), variables('name_nic'))]",
          "location": "[parameters('location')]",
          "copy": {
             "name": "nicLoop",
             "count": "[parameters('numberOfNewNodes')]"
          },
          "dependsOn": [
-            "[resourceId('Microsoft.Network/publicIPAddresses/', concat(variables('name_vmMachine'),copyIndex(parameters('numberOfExistingNodes')),variables('name_publicIPAddress')))]"
+            "[resourceId('Microsoft.Network/publicIPAddresses/', concat(variables('name_vmMachine'),copyIndex(variables('const_appNodeMachineOffset')),variables('name_publicIPAddress')))]"
          ],
          "properties": {
             "ipConfigurations": [
@@ -290,7 +291,7 @@
                   "properties": {
                      "privateIPAllocationMethod": "Dynamic",
                      "publicIPAddress": {
-                        "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat(variables('name_vmMachine'),copyIndex(parameters('numberOfExistingNodes')),variables('name_publicIPAddress')))]"
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat(variables('name_vmMachine'),copyIndex(variables('const_appNodeMachineOffset')),variables('name_publicIPAddress')))]"
                      },
                      "subnet": {
                         "id": "[variables('ref_subnet')]"
@@ -299,14 +300,14 @@
                }
             ],
             "dnsSettings": {
-               "internalDnsNameLabel": "[concat(variables('name_vmMachine'), copyIndex(parameters('numberOfExistingNodes')))]"
+               "internalDnsNameLabel": "[concat(variables('name_vmMachine'), copyIndex(variables('const_appNodeMachineOffset')))]"
             }
          }
       },
       {
          "type": "Microsoft.Compute/virtualMachines",
          "apiVersion": "${azure.apiVersion}",
-         "name": "[concat(variables('name_vmMachine'), copyIndex(parameters('numberOfExistingNodes')))]",
+         "name": "[concat(variables('name_vmMachine'), copyIndex(variables('const_appNodeMachineOffset')))]",
          "location": "[parameters('location')]",
          "copy": {
             "name": "virtualMachineLoop",
@@ -320,7 +321,7 @@
                "vmSize": "[variables('const_vmSize')]"
             },
             "osProfile": {
-               "computerName": "[concat(variables('name_vmMachine'), copyIndex(parameters('numberOfExistingNodes')))]",
+               "computerName": "[concat(variables('name_vmMachine'), copyIndex(variables('const_appNodeMachineOffset')))]",
                "adminUsername": "[parameters('adminUsername')]",
                "adminPassword": "[parameters('adminPasswordOrKey')]",
                "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]"
@@ -352,7 +353,7 @@
             "networkProfile": {
                "networkInterfaces": [
                   {
-                     "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('name_vmMachine'), copyIndex(parameters('numberOfExistingNodes')), variables('name_nic')))]"
+                     "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('name_vmMachine'), copyIndex(variables('const_appNodeMachineOffset')), variables('name_nic')))]"
                   }
                ]
             },
@@ -372,14 +373,14 @@
       {
          "type": "Microsoft.Compute/virtualMachines/extensions",
          "apiVersion": "${azure.apiVersion}",
-         "name": "[concat(variables('name_vmMachine'), copyIndex(parameters('numberOfExistingNodes')), '/newuserscript')]",
+         "name": "[concat(variables('name_vmMachine'), copyIndex(variables('const_appNodeMachineOffset')), '/newuserscript')]",
          "location": "[parameters('location')]",
          "copy": {
             "name": "virtualMachineExtensionLoop",
             "count": "[parameters('numberOfNewNodes')]"
          },
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', concat(variables('name_vmMachine'), copyIndex(parameters('numberOfExistingNodes'))))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', concat(variables('name_vmMachine'), copyIndex(variables('const_appNodeMachineOffset'))))]"
          ],
          "properties": {
             "publisher": "Microsoft.Azure.Extensions",
@@ -393,7 +394,7 @@
                ]
             },
             "protectedSettings": {
-               "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' ',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('managedServerPrefix'),' ',copyIndex(parameters('numberOfExistingNodes')),' ', parameters('adminURL'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('dynamicClusterSize'),' ', variables('const_managedVMPrefix'),' ',parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').certificateBase64String, 'null'),' ',if(parameters('aadsSettings').enable, parameters('aadsSettings').publicIP, 'null'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').serverHost, 'null'),' ', parameters('adminPasswordOrKey'), ' ',parameters('elkSettings').enable,' ', concat(parameters('elkSettings').elasticsearchURI,':',parameters('elkSettings').elasticsearchPort),' ', parameters('elkSettings').elasticsearchUserName,' ', parameters('elkSettings').elasticsearchPassword,' ', array.join(parameters('elkSettings').logsToIntegrate), ' ', parameters('elkSettings').logIndex, ' ', parameters('maxDynamicClusterSize'))]"
+               "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' ',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('managedServerPrefix'),' ',copyIndex(variables('const_appNodeMachineOffset')),' ', parameters('adminURL'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('dynamicClusterSize'),' ', variables('const_managedVMPrefix'),' ',parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').certificateBase64String, 'null'),' ',if(parameters('aadsSettings').enable, parameters('aadsSettings').publicIP, 'null'),' ', if(parameters('aadsSettings').enable, parameters('aadsSettings').serverHost, 'null'),' ', parameters('adminPasswordOrKey'), ' ',parameters('elkSettings').enable,' ', concat(parameters('elkSettings').elasticsearchURI,':',parameters('elkSettings').elasticsearchPort),' ', parameters('elkSettings').elasticsearchUserName,' ', parameters('elkSettings').elasticsearchPassword,' ', array.join(parameters('elkSettings').logsToIntegrate), ' ', parameters('elkSettings').logIndex, ' ', parameters('maxDynamicClusterSize'))]"
             }
          }
       },

--- a/addnode/src/main/scripts/addNodeToDynamicCluster.sh
+++ b/addnode/src/main/scripts/addNodeToDynamicCluster.sh
@@ -574,7 +574,7 @@ start_cluster
 echo "enable ELK? ${enableELK}"
 if [[ "${enableELK,,}" == "true" ]];then
     echo "Set up ELK..."
-    ${SCRIPT_PWD}/elkIntegration.sh \
+    ${SCRIPT_PWD}/elkIntegrationForDynamicCluster.sh \
         ${oracleHome} \
         ${wlsAdminURL} \
         ${managedServerPrefix} \

--- a/arm-oraclelinux-wls-dynamic-cluster/pom.xml
+++ b/arm-oraclelinux-wls-dynamic-cluster/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-dynamic-cluster</artifactId>
-    <version>1.0.21</version>
+    <version>1.0.22</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -689,6 +689,110 @@
                         "visible": "[bool(steps('section_elk').enableELK)]"
                     }
                 ]
+            },
+            {
+                "name": "section_coherence",
+                "label": "Coherence",
+                "subLabel": {
+                    "preValidation": "Configure Coherence.",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Coherence",
+                "elements": [
+                    {
+                        "name": "aboutCoherence",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "icon": "None",
+                            "text": "Selecting 'Yes' here and providing the configuration will cause the template to create a Coherence cluster, the WebLogic Domain will create a data tier configured with Managed Coherence cache servers.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://aka.ms/arm-oraclelinux-wls-coherence"
+                            }
+                        }
+                    },
+                    {
+                        "name": "enableCoherence",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Use Coherence cache?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' and provide required info to configure Coherence cluster.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "coherenceInfo",
+                        "type": "Microsoft.Common.Section",
+                        "label": "Coherence settings",
+                        "elements": [
+                            {
+                                "name": "coherenceVMSizeSelect",
+                                "type": "Microsoft.Compute.SizeSelector",
+                                "label": "Coherence virtual machine size",
+                                "toolTip": "The size of virtual machine for Coherence cache servers.",
+                                "recommendedSizes": [
+                                    "[basics('vmSizeSelect')]"
+                                ],
+                                "constraints": {
+                                    "excludedSizes": [
+                                        "Standard_B1ls",
+                                        "Standard_A0",
+                                        "Basic_A0",
+                                        "Standard_B1s"
+                                    ]
+                                },
+                                "osPlatform": "Linux",
+                                "count": "1",
+                                "visible": true
+                            },
+                            {
+                                "name": "numberOfCoherenceStorageInstances",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Number of Coherence cache servers",
+                                "toolTip": "Number of Coherence cache instances, used to create virtual machines and WebLogic Managed Server.",
+                                "defaultValue": "1",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[0-9]+$",
+                                    "validationMessage": "The value must be a valid number."
+                                }
+                            },
+                            {
+                                "name": "enableCoherenceWebLocalStorage",
+                                "type": "Microsoft.Common.OptionsGroup",
+                                "label": "Coherence Web Local Storage Enabled",
+                                "defaultValue": "Yes",
+                                "toolTip": "Specifies whether Local Storage is enabled for the Coherence*Web cluster tier",
+                                "constraints": {
+                                    "allowedValues": [
+                                        {
+                                            "label": "Yes",
+                                            "value": "true"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "required": true
+                                }
+                            }
+                        ],
+                        "visible": "[bool(steps('section_coherence').enableCoherence)]"
+                    }
+                ]
             }
         ],
         "outputs": {
@@ -709,14 +813,18 @@
             "elasticsearchUserName": "[steps('section_elk').elkInfo.elasticsearchUserName]",
             "dynamicClusterSize": "[int(basics('basicsRequired').dynamicClusterSize)]",
             "enableAAD": "[bool(steps('section_aad').enableAAD)]",
+            "enableCoherence": "[bool(steps('section_coherence').enableCoherence)]",
+            "enableCoherenceWebLocalStorage": "[bool(if(bool(steps('section_coherence').enableCoherence),steps('section_coherence').coherenceInfo.enableCoherenceWebLocalStorage,'false'))]",
             "enableELK": "[bool(steps('section_elk').enableELK)]",
             "jdbcDataSourceName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceName]",
             "logsToIntegrate": "[steps('section_elk').elkInfo.logsToIntegrate]",
             "managedServerPrefix": "[basics('basicsOptional').managedServerPrefix]",
             "maxDynamicClusterSize": "[int(basics('basicsRequired').maxDynamicClusterSize)]",
+            "numberOfCoherenceCacheInstances": "[int(if(bool(steps('section_coherence').enableCoherence),steps('section_coherence').coherenceInfo.numberOfCoherenceCacheInstances,'1'))]",
             "portsToExpose": "[basics('basicsOptional').portsToExpose]",
             "skuUrnVersion": "[basics('skuUrnVersion')]",
             "vmSizeSelect": "[basics('vmSizeSelect')]",
+            "vmSizeSelectForCoherence": "[steps('section_coherence').coherenceInfo.coherenceVMSizeSelect]",
             "wlsDomainName": "[basics('basicsOptional').wlsDomainName]",
             "wlsLDAPGroupBaseDN": "[steps('section_aad').aadInfo.wlsLDAPGroupBaseDN]",
             "wlsLDAPPrincipal": "[steps('section_aad').aadInfo.wlsLDAPPrincipal]",

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
@@ -539,9 +539,6 @@
                     "adminVMName": {
                         "value": "[parameters('adminVMName')]"
                     },
-                    "dynamicClusterSize": {
-                        "value": "[parameters('dynamicClusterSize')]"
-                    },
                     "elasticsearchEndpoint": {
                         "value": "[parameters('elasticsearchEndpoint')]"
                     },
@@ -562,6 +559,9 @@
                     },
                     "maxDynamicClusterSize": {
                         "value": "[parameters('maxDynamicClusterSize')]"
+                    },
+                    "numberOfManagedApplicationInstances": {
+                        "value": "[parameters('dynamicClusterSize')]"
                     },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"
@@ -608,11 +608,29 @@
                     "dnsLabelPrefix": {
                         "value": "[parameters('dnsLabelPrefix')]"
                     },
+                    "elasticsearchEndpoint": {
+                        "value": "[parameters('elasticsearchEndpoint')]"
+                    },
+                    "elasticsearchPassword": {
+                        "value": "[parameters('elasticsearchPassword')]"
+                    },
+                    "elasticsearchUserName": {
+                        "value": "[parameters('elasticsearchUserName')]"
+                    },
                     "enableCoherenceWebLocalStorage": {
                         "value": "[parameters('enableCoherenceWebLocalStorage')]"
                     },
+                    "enableELK": {
+                        "value": "[parameters('enableELK')]"
+                    },
                     "location": {
                         "value": "[parameters('location')]"
+                    },
+                    "logIndex": {
+                        "value": "[if(parameters('enableELK'), reference('elkLinkedTemplate', '${azure.apiVersion}').outputs.logIndex.value, '')]"
+                    },
+                    "logsToIntegrate": {
+                        "value": "[parameters('logsToIntegrate')]"
                     },
                     "managedServerPrefix": {
                         "value": "[parameters('managedServerPrefix')]"

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
@@ -124,6 +124,20 @@
                 "description": "Bool value, if it's set to true, will enable Azure Active Directory after WebLogic Server starts."
             }
         },
+        "enableCoherence": {
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "If true, create Coherence cluster with data tier for cache."
+            }
+        },
+        "enableCoherenceWebLocalStorage": {
+            "defaultValue": true,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether Local Storage is enabled for the Coherence*Web cluster tier."
+            }
+        },
         "enableDB": {
             "defaultValue": false,
             "type": "bool",
@@ -174,6 +188,15 @@
                 "description": "Maximum Number of Managed Servers allowed to be configured in the Dynamic Cluster"
             }
         },
+         "numberOfCoherenceCacheInstances": {
+            "defaultValue": 1,
+            "type": "int",
+            "minValue": 1,
+            "maxValue": 10,
+            "metadata": {
+                "description": "Number of Coherence cache instances, used to create virtual machines and Managed Server."
+            }
+        },
         "portsToExpose": {
             "defaultValue": "80,443,7001-9000",
             "type": "string",
@@ -207,6 +230,13 @@
             "type": "string",
             "metadata": {
                 "description": "Select appropriate VM Size as per requirement"
+            }
+        },
+        "vmSizeSelectForCoherence": {
+            "defaultValue": "Standard_A3",
+            "type": "string",
+            "metadata": {
+                "description": "Select appropriate VM Size for Coherence"
             }
         },
         "wlsDomainName": {
@@ -276,7 +306,8 @@
         "name_aadLinkedTemplateName": "aadNestedTemplate.json",
         "name_clusterLinkedTemplateName": "clusterTemplate.json",
         "name_dbLinkedTemplateName": "dbTemplate.json",
-        "name_elkLinkedTemplateName": "elkNestedTemplate.json"
+        "name_elkLinkedTemplateName": "elkNestedTemplate.json",
+        "name_coherenceTemplateName": "coherenceTemplate.json"
     },
     "resources": [
         {
@@ -545,6 +576,75 @@
             }
         },
         {
+            "name": "coherenceTemplate",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'elkLinkedTemplate')]"
+            ],
+            "apiVersion": "${azure.apiVersion}",
+            "condition": "[parameters('enableCoherence')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/', variables('name_coherenceTemplateName')))]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "_artifactsLocation": {
+                        "value": "[parameters('_artifactsLocation')]"
+                    },
+                    "_artifactsLocationSasToken": {
+                        "value": "[parameters('_artifactsLocationSasToken')]"
+                    },
+                    "adminPasswordOrKey": {
+                        "value": "[parameters('adminPasswordOrKey')]"
+                    },
+                    "adminUsername": {
+                        "value": "[parameters('adminUsername')]"
+                    },
+                    "adminVMName": {
+                        "value": "[parameters('adminVMName')]"
+                    },
+                    "dnsLabelPrefix": {
+                        "value": "[parameters('dnsLabelPrefix')]"
+                    },
+                    "enableCoherenceWebLocalStorage": {
+                        "value": "[parameters('enableCoherenceWebLocalStorage')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "managedServerPrefix": {
+                        "value": "[parameters('managedServerPrefix')]"
+                    },
+                    "numberOfCoherenceCacheInstances": {
+                        "value": "[parameters('numberOfCoherenceCacheInstances')]"
+                    },
+                    "skuUrnVersion": {
+                        "value": "[parameters('skuUrnVersion')]"
+                    },
+                    "storageAccountName": {
+                        "value": "[reference('clusterLinkedTemplate', '${azure.apiVersion}').outputs.storageAccountName.value]"
+                    },
+                    "usePreviewImage": {
+                        "value": "[parameters('usePreviewImage')]"
+                    },
+                    "vmSizeSelectForCoherence": {
+                        "value": "[parameters('vmSizeSelectForCoherence')]"
+                    },
+                    "wlsDomainName": {
+                        "value": "[parameters('wlsDomainName')]"
+                    },
+                    "wlsPassword": {
+                        "value": "[parameters('wlsPassword')]"
+                    },
+                    "wlsUserName": {
+                        "value": "[parameters('wlsUserName')]"
+                    }
+                }
+            }
+        },
+        {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
             "name": "${dynamic.end}",
@@ -552,7 +652,8 @@
                 "[resourceId('Microsoft.Resources/deployments', 'clusterLinkedTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'aadLinkedTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'dbLinkedTemplate')]",
-                "[resourceId('Microsoft.Resources/deployments', 'elkLinkedTemplate')]"
+                "[resourceId('Microsoft.Resources/deployments', 'elkLinkedTemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'coherenceTemplate')]"
             ],
             "properties": {
                 "mode": "Incremental",
@@ -569,23 +670,23 @@
     "outputs": {
         "wlsDomainLocation": {
             "type": "string",
-            "value": "[reference('clusterLinkedTemplate','2019-10-01').outputs.wlsDomainLocation.value]"
+            "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.wlsDomainLocation.value]"
         },
         "adminHostName": {
             "type": "string",
-            "value": "[reference('clusterLinkedTemplate','2019-10-01').outputs.adminHostName.value]"
+            "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminHostName.value]"
         },
         "adminConsole": {
             "type": "string",
-            "value": "[reference('clusterLinkedTemplate','2019-10-01').outputs.adminConsole.value]"
+            "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminConsole.value]"
         },
         "adminSecuredConsole": {
             "type": "string",
-            "value": "[reference('clusterLinkedTemplate','2019-10-01').outputs.adminSecuredConsole.value]"
+            "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminSecuredConsole.value]"
         },
         "logIndex": {
             "type": "string",
-            "value": "[if(parameters('enableELK'), reference('elkLinkedTemplate', '2019-10-01').outputs.logIndex.value, '')]"
+            "value": "[if(parameters('enableELK'), reference('elkLinkedTemplate', '${azure.apiVersion}').outputs.logIndex.value, '')]"
         }
     }
 }

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -249,7 +249,7 @@
         },
         {
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2019-06-01",
+            "apiVersion": "${azure.apiVersion2}",
             "name": "[variables('name_storageAccount')]",
             "location": "[parameters('location')]",
             "sku": {
@@ -262,7 +262,7 @@
         },
         {
 			"type": "Microsoft.Storage/storageAccounts/fileServices",
-			"apiVersion": "2019-06-01",
+			"apiVersion": "${azure.apiVersion2}",
 			"name": "[concat(variables('name_storageAccount'), '/default')]",
 			"dependsOn": [
 				"[variables('ref_storage')]"
@@ -274,7 +274,7 @@
 		},
 		{
 			"type": "Microsoft.Storage/storageAccounts/fileServices/shares",
-			"apiVersion": "2019-06-01",
+			"apiVersion": "${azure.apiVersion2}",
 			"name": "[concat(variables('name_storageAccount'), '/default/', variables('name_share'))]",
 			"dependsOn": [
 				"[variables('ref_fileService')]",
@@ -416,7 +416,7 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": true,
-                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', variables('name_storageAccount')), '2019-06-01').primaryEndpoints.blob]"
+                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', variables('name_storageAccount')), '${azure.apiVersion2}').primaryEndpoints.blob]"
                     }
                 }
             },

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -572,15 +572,19 @@
         },
         "adminHostName": {
             "type": "string",
-            "value": "[reference(variables('name_outputAdminHost'), '2019-11-01').dnsSettings.fqdn]"
+            "value": "[reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn]"
         },
         "adminConsole": {
             "type": "string",
-            "value": "[concat('http://',reference(variables('name_outputAdminHost'), '2019-11-01').dnsSettings.fqdn,':7001/console')]"
+            "value": "[concat('http://',reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn,':7001/console')]"
         },
         "adminSecuredConsole": {
             "type": "string",
-            "value": "[concat('https://',reference(variables('name_outputAdminHost'), '2019-11-01').dnsSettings.fqdn,':7002/console')]"
+            "value": "[concat('https://',reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn,':7002/console')]"
+        },
+        "storageAccountName": {
+            "type": "string",
+            "value": "[variables('name_storageAccount')]"
         }
     }
 }

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/coherenceTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/coherenceTemplate.json
@@ -1,0 +1,369 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "_artifactsLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+            }
+        },
+        "_artifactsLocationCoherenceTemplate": {
+            "defaultValue": "[if(contains(parameters('_artifactsLocation'), 'githubusercontent'), parameters('_artifactsLocation'), deployment().properties.templateLink.uri)]",
+            "type": "string",
+            "metadata": {
+                "description": "If we are deploying from the command line, use the passed in _artifactsLocation, otherwise use the default."
+            }
+        },
+        "_artifactsLocationSasToken": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured."
+            },
+            "defaultValue": ""
+        },
+        "adminPasswordOrKey": {
+            "type": "securestring",
+            "metadata": {
+                "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "defaultValue": "weblogic",
+            "metadata": {
+                "description": "User name for the Virtual Machine."
+            }
+        },
+        "adminVMName": {
+            "defaultValue": "adminVM",
+            "type": "string",
+            "metadata": {
+                "description": "Admin Server hosting VM name."
+            }
+        },
+        "authenticationType": {
+            "type": "string",
+            "defaultValue": "password",
+            "allowedValues": [
+                "sshPublicKey",
+                "password"
+            ],
+            "metadata": {
+                "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+            }
+        },
+        "dnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "wls",
+            "metadata": {
+                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "enableCoherenceWebLocalStorage": {
+            "defaultValue": true,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether Local Storage is enabled for the Coherence*Web cluster tier."
+            }
+        },
+        "guidValue": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "managedServerPrefix": {
+            "type": "string",
+            "defaultValue": "msp",
+            "metadata": {
+                "description": "Provide managed server prefix name"
+            }
+        },
+        "numberOfCoherenceCacheInstances": {
+            "defaultValue": 1,
+            "type": "int",
+            "minValue": 1,
+            "maxValue": 10,
+            "metadata": {
+                "description": "Number of Coherence cache instances, used to create Virtual Machines and Managed Server."
+            }
+        },
+        "skuUrnVersion": {
+            "type": "string",
+            "defaultValue": "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;latest",
+            "allowedValues": [
+                "owls-122130-8u131-ol73;Oracle:weblogic-122130-jdk8u131-ol73:owls-122130-8u131-ol7;latest",
+                "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;latest",
+                "owls-122140-8u251-ol76;Oracle:weblogic-122140-jdk8u251-ol76:owls-122140-8u251-ol7;latest",
+                "owls-141100-8u251-ol76;Oracle:weblogic-141100-jdk8u251-ol76:owls-141100-8u251-ol7;latest",
+                "owls-141100-11_07-ol76;Oracle:weblogic-141100-jdk11_07-ol76:owls-141100-11_07-ol7;latest"
+            ],
+            "metadata": {
+                "description": "The Oracle Linux image with Weblogic and Java preinstalled. Semicolon separated string of Sku, URN, and Version"
+            }
+        },
+        "storageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of storage account. One storage account can store 20 vitual machines with 2 VHDs of 500 IOPS."
+            }
+        },
+        "usePreviewImage": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Bool value, if it's set to true, will deploy with preview weblogic image."
+            }
+        },
+        "vmSizeSelectForCoherence": {
+            "defaultValue": "Standard_A3",
+            "type": "string",
+            "metadata": {
+                "description": "Select appropriate VM Size for Coherence"
+            }
+        },
+        "wlsDomainName": {
+            "type": "string",
+            "defaultValue": "wlsd",
+            "metadata": {
+                "description": "Provide Weblogic domain name"
+            }
+        },
+        "wlsPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for your Weblogic domain name"
+            }
+        },
+        "wlsUserName": {
+            "defaultValue": "weblogic",
+            "type": "string",
+            "metadata": {
+                "description": "Username for your Weblogic domain name"
+            }
+        }
+    },
+    "variables": {
+        "const_hyphen": "-",
+        "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),'jdk',split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
+        "const_imagePublisher": "oracle",
+        "const_linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                        "keyData": "[parameters('adminPasswordOrKey')]"
+                    }
+                ]
+            }
+        },
+        "const_mountPointPath": "[concat('/mnt/', variables('name_share'))]",
+        "const_publicIPAddressType": "Dynamic",
+        "const_vmSize": "[parameters('vmSizeSelectForCoherence')]",
+        "const_wlsDomainPath": "/u01/domains",
+        "const_wlsHome": "/u01/app/wls/install/oracle/middleware/oracle_home",
+        "name_linuxImageOfferSKU": "[first(split(parameters('skuUrnVersion'), ';'))]",
+        "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
+        "name_nic": "_NIC",
+        "name_publicIPAddress": "_PublicIP",
+        "name_scriptFile": "setupCoherence.sh",
+        "name_share": "wlsshare",
+        "name_subnet": "Subnet",
+        "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+        "name_vmMachine": "[concat(parameters('managedServerPrefix'),'StorageVM')]",
+        "name_wlsServerPrefix": "[concat(parameters('managedServerPrefix'),'Storage')]",
+        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]"
+    },
+    "resources": [
+        {
+            "apiVersion": "${azure.apiVersion}",
+            "name": "${dynamic.coherence.start}",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_vmMachine'),copyIndex(1),variables('name_publicIPAddress'))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "publicIPLoop",
+                "count": "[parameters('numberOfCoherenceCacheInstances')]"
+            },
+            "properties": {
+                "publicIPAllocationMethod": "[variables('const_publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[concat(toLower(parameters('dnsLabelPrefix')),copyindex(1),'-',take(replace(parameters('guidValue'),'-',''),10),'-',toLower(parameters('wlsDomainName')))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_virtualNetwork'), '/', variables('name_subnet'))]",
+            "condition": "[and(empty(variables('name_virtualNetwork')), empty(variables('name_subnet')))]"
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_vmMachine'), copyIndex(1), variables('name_nic'))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "nicLoop",
+                "count": "[parameters('numberOfCoherenceCacheInstances')]"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(variables('name_vmMachine'),copyIndex(1),variables('name_publicIPAddress')))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat(variables('name_vmMachine'),copyIndex(1),variables('name_publicIPAddress')))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ],
+                "dnsSettings": {
+                    "internalDnsNameLabel": "[concat(variables('name_vmMachine'), copyIndex(1))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_vmMachine'), copyIndex(1))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[parameters('numberOfCoherenceCacheInstances')]"
+            },
+            "dependsOn": [
+                "nicLoop"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('const_vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('name_vmMachine'), copyIndex(1))]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPasswordOrKey')]",
+                    "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('const_imagePublisher')]",
+                        "offer": "[variables('const_imageOffer')]",
+                        "sku": "[variables('name_linuxImageOfferSKU')]",
+                        "version": "[variables('name_linuxImageVersion')]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "Standard_LRS"
+                        }
+                    },
+                    "dataDisks": [
+                        {
+                            "lun": 0,
+                            "createOption": "FromImage",
+                            "diskSizeGB": 900,
+                            "managedDisk": {
+                                "storageAccountType": "Standard_LRS"
+                            }
+                        }
+                    ]
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('name_vmMachine'), copyIndex(1), variables('name_nic')))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true,
+                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '2019-06-01').primaryEndpoints.blob]"
+                    }
+                }
+            },
+            "plan": {
+                "name": "[variables('name_linuxImageOfferSKU')]",
+                "publisher": "[variables('const_imagePublisher')]",
+                "product": "[variables('const_imageOffer')]"
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[if(equals(copyIndex(),0),concat(parameters('adminVMName'),'/newuserscript'),concat(variables('name_vmMachine'), copyIndex(),'/newuserscript'))]",
+            "apiVersion": "${azure.apiVersion}",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "virtualMachineExtensionLoop",
+                "count": "[add(parameters('numberOfCoherenceCacheInstances'),1)]"
+            },
+            "dependsOn": [
+                "virtualMachineLoop"
+            ],
+            "properties": {
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "fileUris": [
+                        "[uri(parameters('_artifactsLocationCoherenceTemplate'), concat('../scripts/', variables('name_scriptFile'), parameters('_artifactsLocationSasToken')))]"
+                    ]
+                },
+                "protectedSettings": {
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'), ' ', parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',if(equals(copyIndex(),0),'admin',concat(variables('name_wlsServerPrefix'),copyIndex())),' ', parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', parameters('enableCoherenceWebLocalStorage'))]"
+                }
+            }
+        },
+        {
+            "apiVersion": "${azure.apiVersion}",
+            "name": "${dynamic.coherence.end}",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "virtualMachineExtensionLoop"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "artifactsLocationPassedIn": {
+            "type": "string",
+            "value": "[parameters('_artifactsLocation')]"
+        }
+    }
+}

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/coherenceTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/coherenceTemplate.json
@@ -60,11 +60,39 @@
                 "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
             }
         },
+        "elasticsearchEndpoint": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Endpoint of the Elasticsearch instance."
+            }
+        },
+        "elasticsearchPassword": {
+            "type": "securestring",
+            "defaultValue": "[newGuid()]",
+            "metadata": {
+                "description": "The credentials to distribute message to Elasticsearch instance with REST API."
+            }
+        },
+        "elasticsearchUserName": {
+            "type": "string",
+            "defaultValue": "elastic",
+            "metadata": {
+                "description": "The credentials to distribute message to Elasticsearch instance with REST API."
+            }
+        },
         "enableCoherenceWebLocalStorage": {
             "defaultValue": true,
             "type": "bool",
             "metadata": {
                 "description": "Specifies whether Local Storage is enabled for the Coherence*Web cluster tier."
+            }
+        },
+        "enableELK": {
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "If true, use the supplied parameters to distribute WebLogic Server logs to the Elasticsearch instance."
             }
         },
         "guidValue": {
@@ -75,6 +103,21 @@
             "type": "string",
             "metadata": {
                 "description": "Location for all resources."
+            }
+        },
+        "logIndex": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Elasticsearch index you expect to export the logs to."
+            }
+        },
+        "logsToIntegrate": {
+            "type": "array",
+            "defaultValue": [ "HTTPAccessLog", "ServerLog", "DomainLog", "DataSourceLog", "StandardErrorAndOutput", "NodeManagerLog" ],
+            "allowedValues": [ "HTTPAccessLog", "ServerLog", "DomainLog", "DataSourceLog", "StandardErrorAndOutput","NodeManagerLog" ],
+            "metadata": {
+                "description": "Specify the expeted logs to integrate, you must input at least one log."
             }
         },
         "managedServerPrefix": {
@@ -165,6 +208,7 @@
         },
         "const_mountPointPath": "[concat('/mnt/', variables('name_share'))]",
         "const_publicIPAddressType": "Dynamic",
+        "const_singleQuote": "'",
         "const_vmSize": "[parameters('vmSizeSelectForCoherence')]",
         "const_wlsDomainPath": "/u01/domains",
         "const_wlsHome": "/u01/app/wls/install/oracle/middleware/oracle_home",
@@ -173,6 +217,7 @@
         "name_nic": "_NIC",
         "name_publicIPAddress": "_PublicIP",
         "name_scriptFile": "setupCoherence.sh",
+        "name_scriptELKConfiguration": "elkIntegrationForConfiguredCluster.sh",
         "name_share": "wlsshare",
         "name_subnet": "Subnet",
         "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
@@ -180,6 +225,25 @@
         "name_wlsServerPrefix": "[concat(parameters('managedServerPrefix'),'Storage')]",
         "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]"
     },
+    "functions": [
+        {
+            "namespace": "array",
+            "members": {
+                "join": {
+                    "parameters": [
+                        {
+                            "name": "items",
+                            "type": "array"
+                        }
+                    ],
+                    "output": {
+                        "type": "string",
+                        "value": "[replace(replace(replace(string(parameters('items')), '[\"', ''), '\"]', ''), '\",\"', ',')]"
+                    }
+                }
+            }
+        }
+    ],
     "resources": [
         {
             "apiVersion": "${azure.apiVersion}",
@@ -305,7 +369,7 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": true,
-                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '2019-06-01').primaryEndpoints.blob]"
+                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '${azure.apiVersion2}').primaryEndpoints.blob]"
                     }
                 }
             },
@@ -334,11 +398,12 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "fileUris": [
-                        "[uri(parameters('_artifactsLocationCoherenceTemplate'), concat('../scripts/', variables('name_scriptFile'), parameters('_artifactsLocationSasToken')))]"
+                        "[uri(parameters('_artifactsLocationCoherenceTemplate'), concat('../scripts/', variables('name_scriptFile'), parameters('_artifactsLocationSasToken')))]",
+                        "[uri(parameters('_artifactsLocationCoherenceTemplate'), concat('../scripts/', variables('name_scriptELKConfiguration'), parameters('_artifactsLocationSasToken')))]"
                     ]
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'), ' ', parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',if(equals(copyIndex(),0),'admin',concat(variables('name_wlsServerPrefix'),copyIndex())),' ', parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', parameters('enableCoherenceWebLocalStorage'))]"
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'), ' ', parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',' ', parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('const_wlsDomainPath'),' ', parameters('storageAccountName'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-04-01').keys[0].value,' ', variables('const_mountPointPath'),' ', parameters('enableCoherenceWebLocalStorage'), ' ',parameters('enableELK'),' ',variables('const_singleQuote'),parameters('elasticsearchEndpoint'),variables('const_singleQuote'),' ',variables('const_singleQuote'),parameters('elasticsearchUserName'),variables('const_singleQuote'),' ',variables('const_singleQuote'),parameters('elasticsearchPassword'),variables('const_singleQuote'),' ',array.join(parameters('logsToIntegrate')),' ',variables('const_singleQuote'),parameters('logIndex'),variables('const_singleQuote'),' ',variables('name_wlsServerPrefix'),' ',copyIndex())]"
                 }
             }
         },

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/elkNestedTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/elkNestedTemplate.json
@@ -29,13 +29,6 @@
                 "description": "Admin Server hosting VM name."
             }
         },
-        "dynamicClusterSize": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "Number of Managed Servers that have been configured in the Dynamic Cluster."
-            }
-        },
         "elasticsearchEndpoint": {
             "type": "string",
             "defaultValue": "",
@@ -52,7 +45,7 @@
         },
         "elasticsearchUserName": {
             "type": "string",
-            "defaultValue": "",
+            "defaultValue": "elastic",
             "metadata": {
                 "description": "The credentials to distibute message with REST API to Elasticsearch instance."
             }
@@ -98,6 +91,15 @@
                 "description": "Number of VMs that have been deployed to host managed cache server, please set the value if your cluster is Coherence cluster."
             }
         },
+        "numberOfManagedApplicationInstances": {
+            "type": "int",
+            "defaultValue": 2,
+            "minValue": 1,
+            "maxValue": 20,
+            "metadata": {
+                "description": "Number of VMs that have been deployed to host managed application server."
+            }
+        },
         "wlsDomainName": {
             "type": "string",
             "defaultValue": "wlsd",
@@ -126,7 +128,7 @@
         "const_wlsAdminPort": "7001",
         "const_wlsDomainPath": "[concat('/u01/domains/', parameters('wlsDomainName'))]",
         "const_wlsHome": "/u01/app/wls/install/oracle/middleware/oracle_home",
-        "name_scriptELKConfiguration": "elkIntegration.sh"
+        "name_scriptELKConfiguration": "elkIntegrationForDynamicCluster.sh"
     },
     "functions": [
         {
@@ -189,7 +191,7 @@
             "location": "[parameters('location')]",
             "copy": {
                 "name": "appVirtualMachineExtensionLoop",
-                "count": "[parameters('dynamicClusterSize')]"
+                "count": "[parameters('numberOfManagedApplicationInstances')]"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('adminVMName'), 'newuserscript')]"

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/elkIntegrationForConfiguredCluster.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/elkIntegrationForConfiguredCluster.sh
@@ -1,0 +1,729 @@
+#!/bin/bash
+
+#Function to output message to StdErr
+function echo_stderr() {
+    echo "$@" >&2
+}
+
+#Function to display usage message
+function usage() {
+    echo_stderr "./elkIntegrationForConfiguredCluster.sh <oracleHome> <wlsAdminURL> <wlsUserName> <wlsPassword> <wlsAdminServerName> <elasticURI> <elasticUserName> <elasticPassword> <wlsDomainName> <wlsDomainPath> <logsToIntegrate> <index> <logIndex> <managedServerPrefix>"
+}
+
+function validate_input() {
+    if [ -z "$oracleHome" ]; then
+        echo_stderr "oracleHome is required. "
+        exit 1
+    fi
+
+    if [ -z "$wlsAdminURL" ]; then
+        echo_stderr "wlsAdminURL is required. "
+        exit 1
+    fi
+
+    if [[ -z "$wlsUserName" || -z "$wlsPassword" ]]; then
+        echo_stderr "wlsUserName or wlsPassword is required. "
+        exit 1
+    fi
+
+    if [ -z "$wlsAdminServerName" ]; then
+        echo_stderr "wlsAdminServerName is required. "
+        exit 1
+    fi
+
+    if [ -z "$elasticURI" ]; then
+        echo_stderr "elasticURI is required. "
+        exit 1
+    fi
+
+    if [[ -z "$elasticUserName" || -z "$elasticPassword" ]]; then
+        echo_stderr "elasticUserName or elasticPassword is required. "
+        exit 1
+    fi
+
+    if [ -z "$wlsDomainName" ]; then
+        echo_stderr "wlsDomainName is required. "
+        exit 1
+    fi
+
+    if [ -z "$wlsDomainPath" ]; then
+        echo_stderr "wlsDomainPath is required. "
+        exit 1
+    fi
+
+    if [ -z "$index" ]; then
+        echo_stderr "index is required. "
+        exit 1
+    fi
+
+    if [ -z "$logsToIntegrate" ]; then
+        echo_stderr "logsToIntegrate is required. "
+        exit 1
+    fi
+
+    if [ -z "$logIndex" ]; then
+        echo_stderr "logIndex is required. "
+        exit 1
+    fi
+
+    if [ -z "$managedServerPrefix" ]; then
+        echo_stderr "managedServerPrefix is required. "
+        exit 1
+    fi
+}
+
+# Set access log with format: date time time-taken bytes c-ip  s-ip c-dns s-dns  cs-method cs-uri sc-status sc-comment ctx-ecid
+# Redirect stdout logging enabled: true
+# Redirect stderr logging enabled: true
+# Stack Traces to stdout: true
+function create_wls_log_model() {
+    cat <<EOF >${SCRIPT_PWD}/configure-wls-log.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+servers=cmo.getServers()
+
+try:
+    edit("$hostName")
+    startEdit()
+    for server in servers:
+        bean="/ServerLifeCycleRuntimes/"+server.getName()
+        cd('/Servers/'+server.getName()+'/WebServer/'+server.getName()+'/WebServerLog/'+server.getName())
+        cmo.setLogFileFormat('extended')
+        cmo.setELFFields('date time time-taken bytes c-ip  s-ip c-dns s-dns  cs-method cs-uri sc-status sc-comment ctx-ecid ctx-rid') 
+
+        cd('/Servers/'+server.getName()+'/Log/'+server.getName())
+        cmo.setRedirectStderrToServerLogEnabled(true)
+        cmo.setRedirectStdoutToServerLogEnabled(true)
+        cmo.setStdoutLogStack(true)
+
+    save()
+    resolve()
+    activate()
+except:
+    stopEdit('y')
+    sys.exit(1)
+
+destroyEditSession("$hostName",force = true)
+disconnect()
+EOF
+}
+
+# Remove existing Logstash
+function remove_logstash() {
+    sudo systemctl status logstash
+    if [ $? -ne 0 ]; then
+        sudo systemctl stop logstash
+    fi
+
+    sudo yum remove -y -v logstash
+    if [ $? -ne 0 ]; then
+        echo_stderr "Fail to remove existing Logstash."
+        exit 1
+    fi
+}
+
+# Install Logstash
+function install_logstash() {
+    sudo rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
+
+    cat <<EOF >/etc/yum.repos.d/logstash.repo
+[logstash-7.x]
+name=Elastic repository for 7.x packages
+baseurl=https://artifacts.elastic.co/packages/7.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+EOF
+    sudo yum install -y -v logstash
+    if [ ! -d "/usr/share/logstash" ]; then
+        echo_stderr "Fail to install Logstash."
+        exit 1
+    fi
+}
+
+# Start Logstash service
+function start_logstash() {
+    sudo systemctl enable logstash
+    sudo systemctl daemon-reload
+
+    #Start logstash
+    attempt=1
+    while [[ $attempt -lt 4 ]]; do
+        echo "Starting logstash service attempt $attempt"
+        sudo systemctl start logstash
+        attempt=$(expr $attempt + 1)
+        sudo systemctl status logstash | grep running
+        if [[ $? == 0 ]]; then
+            echo "logstash service started successfully"
+            break
+        fi
+        sleep 1m
+    done
+}
+
+# Configure Logstash:
+#  * grok patterns -> /etc/logstash/patterns/weblogic-logstash-patterns.txt
+#  * conf files -> /etc/logstash/conf.d
+#  * JAVA_HOME -> /etc/logstash/startup.options
+#  * create logstash start up
+# Examples for patterns:
+#  * ACCESSDATE
+#   * parse date of access
+#   * 2020-09-01
+#  * DBDATETIME
+#   * parse data source datetime
+#   * Tue Sep 01 05:05:41 UTC 2020
+#  * DSIDORTIMESTAMP
+#   * parse data source dynamic fields: id | timestamp, one of them exists.
+#   * timestamp: Tue Sep 01 05:05:41 UTC 2020
+#   * id: 64
+#  * DSPARTITION
+#   * parse partition info.
+#   * [partition-name: DOMAIN] [partition-id: 0]
+#   * [partition-id: 0] [partition-name: DOMAIN]
+#  * DSWEBLOGICMESSAGE
+#   * parse data source user id or error messsage.
+#   * error: Java stack trace
+#   * user id: <anonymous>
+#  * WEBLOGICDIAGMESSAGE
+#   * parse domain log message.
+#   * e.g. Java stack trace
+#   * e.g. Self-tuning thread pool contains 0 running threads, 2 idle threads, and 13 standby threads
+#  * WEBLOGICDOMAINDATE
+#   * parse domain|server log datetime.
+#   * from wls 14: Sep 1, 2020, 5:41:51,040 AM Coordinated Universal Time
+#   * from wls 12: Sep 1, 2020 5:41:51,040 AM Coordinated Universal Time
+#  * WEBLOGICLOGPARTITION
+#   * parse partition info in domain log.
+#   * [severity-value: 64]
+#   * [severity-value: 64] [rid: 0]
+#   * [severity-value: 64] [partition-id: 0] [partition-name: DOMAIN ]
+#   * [severity-value: 64] [rid: 0] [partition-id: 0] [partition-name: DOMAIN ]
+#  * WEBLOGICSERVERLOGPARTITION
+#   * parse partition info in server log.
+#   * [severity-value: 64]
+#   * [severity-value: 64] [rid: 0]
+#   * [severity-value: 64] [partition-id: 0] [partition-name: DOMAIN ]
+#   * [severity-value: 64] [rid: 0] [partition-id: 0] [partition-name: DOMAIN ]
+#  * WEBLOGICSERVERRID
+#   * parse dynamic filed rid in server log.
+#   * [rid: 0]
+#  * WEBLOGICSERVERMESSAGE
+#   * parse field message in server log.
+#   * e.g. Java stack trace
+#   * e.g. Self-tuning thread pool contains 0 running threads, 2 idle threads, and 13 standby threads
+#  * WEBLOGICSTDDATE
+#   * parse field date in std log.
+#   * Aug 31, 2020 5:37:27,646 AM UTC
+#   * Aug 31, 2020 5:37:27 AM UTC
+function configure_lostash() {
+    echo "create patterns"
+    rm -f -r /etc/logstash/patterns
+    if [ -d "/etc/logstash/patterns" ]; then
+        rm -f /etc/logstash/patterns/weblogic-logstash-patterns.txt
+    else
+        mkdir /etc/logstash/patterns
+    fi
+    cat <<EOF >/etc/logstash/patterns/weblogic-logstash-patterns.txt
+ACCESSDATE ^\d{4}[./-]%{MONTHNUM}[./-]%{MONTHDAY}
+DBDATETIME %{DAY} %{MONTH:db_month} %{MONTHDAY:db_day} %{HOUR:db_hour}:%{MINUTE:db_minute}:%{SECOND:db_second} %{TZ:db_tz} %{YEAR:db_year}
+DSIDORTIMESTAMP (?<ds_Id>(\b(?:[1-9][0-9]*)\b))|%{DBDATETIME:ds_timestamp}
+DSPARTITION (?:\[partition-id: %{INT:ds_partitionId}\] \[partition-name: %{DATA:ds_partitionName}\]\s)|(?:\[partition-name: %{DATA:ds_partitionName}\] \[partition-id: %{INT:ds_partitionId}\]\s)
+DSWEBLOGICMESSAGE (?<ds_error>(.|\r|\n)*)|%{GREEDYDATA:ds_user}
+JAVAPACKAGE ([a-zA-Z_$][a-zA-Z\d_$]*\.)*[a-zA-Z_$][a-zA-Z\d_$]*
+NODEMANAGERMESSAGE (?<node_message>(.|\r|\n[^A-Za-z0-9])*)|%{GREEDYDATA:node_message}
+NODEMANAGEREND (<%{WORDNOSPACES:node_domain}>\s<%{WORDNOSPACES:node_server}>\s<%{NODEMANAGERMESSAGE}>)|(<%{GREEDYDATA:node_messageType}>\s<%{NODEMANAGERMESSAGE}>)|<%{NODEMANAGERMESSAGE}>
+WEBLOGICDIAGMESSAGE (?<diag_message>(.|\r|\n)*)|%{GREEDYDATA:diag_message}
+WEBLOGICDOMAINDATE %{MONTH:tmp_month} %{MONTHDAY:tmp_day}, %{YEAR:tmp_year},? %{HOUR:tmp_hour}:%{MINUTE:tmp_min}:%{SECOND:tmp_second},(?<tmp_sss>([0-9]{3})) (?<tmp_aa>(AM|PM))
+WEBLOGICLOGPARTITION (?:\s\[rid: %{DATA:diag_rid}\] \[partition-id: %{INT:diag_partitionId}\] \[partition-name: %{DATA:diag_partitionName}\]\s)|(?:\s\[partition-id: %{INT:diag_partitionId}\] \[partition-name: %{DATA:diag_partitionName}\]\s)|(?:\s\[rid: %{DATA:diag_rid}\]\s)|(\s)
+WEBLOGICSERVERLOGPARTITION (?:\s\[rid: %{DATA:log_rid}\] \[partition-id: %{INT:log_partitionId}\] \[partition-name: %{DATA:log_partitionName}\]\s)|(?:\s\[partition-id: %{INT:log_partitionId}\] \[partition-name: %{DATA:log_partitionName}\]\s)|(?:\s\[rid: %{DATA:log_rid}\]\s)|(\s)
+WEBLOGICSERVERRID (?:\s\[rid: %{WORDNOSPACES:log_rid}\]\s)|(\s)
+WEBLOGICSERVERMESSAGE (?<log_message>(.|\r|\n)*)|%{GREEDYDATA:log_message}
+WEBLOGICSTDDATE %{MONTH:tmp_month} %{MONTHDAY:tmp_day}, %{YEAR:tmp_year},? %{HOUR:tmp_hour}:%{MINUTE:tmp_min}:%{SECOND:tmp_second} (?<tmp_aa>(AM|PM))
+WEBLOGICSTDMESSAGE (?<out_message>(.|\r|\n[^A-Za-z0-9])*)|%{GREEDYDATA:out_message}
+WEBLOGICSTDDYNAMICID (<%{WORDNOSPACES:out_messageId}>\s<%{WEBLOGICSTDMESSAGE}>)|<%{WEBLOGICSTDMESSAGE}>
+WORDNOSPACES [^ ]*
+WORDNOBRACKET [^\]]*
+WORDWITHSPACE (\b\w+\b|\s)*
+EOF
+
+    if [ $index -eq 0 ]; then
+        serverName=$wlsAdminServerName
+    else
+        serverName="${managedServerPrefix}${index}"
+    fi
+    wlsLogPath="${wlsDomainPath}/servers/${serverName}/logs"
+    privateIP=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+
+    rm -f /etc/logstash/conf.d/weblogic-logs.conf
+    cat <<EOF >/etc/logstash/conf.d/weblogic-logs.conf
+input {
+EOF
+
+    if [[ -n $(echo ${logsToIntegrate} | grep "HTTPAccessLog") ]]; then
+        cat <<EOF >>/etc/logstash/conf.d/weblogic-logs.conf
+   file {
+    path => "${wlsLogPath}/access.log"
+    start_position => beginning
+   }
+EOF
+    fi
+
+    if [[ -n $(echo ${logsToIntegrate} | grep "ServerLog") ]]; then
+        cat <<EOF >>/etc/logstash/conf.d/weblogic-logs.conf
+   file {
+    path => "${wlsLogPath}/${serverName}.log"
+    codec => multiline {
+        pattern => "^####"
+        negate => true
+        what => "previous"
+    }
+    start_position => beginning
+   }
+EOF
+    fi
+
+    if [[ -n $(echo ${logsToIntegrate} | grep "DomainLog") ]]; then
+        cat <<EOF >>/etc/logstash/conf.d/weblogic-logs.conf
+   file {
+    path => "${wlsLogPath}/${wlsDomainName}.log"
+    codec => multiline {
+        pattern => "^####"
+        negate => true
+        what => "previous"
+    }
+    start_position => beginning
+   }
+EOF
+    fi
+
+    if [[ -n $(echo ${logsToIntegrate} | grep "DataSourceLog") ]]; then
+        cat <<EOF >>/etc/logstash/conf.d/weblogic-logs.conf
+   file {
+    path => "${wlsLogPath}/datasource.log"
+    codec => multiline {
+        pattern => "^####"
+        negate => true
+        what => "previous"
+    }
+    start_position => beginning
+   }
+EOF
+    fi
+
+    if [[ -n $(echo ${logsToIntegrate} | grep "StandardErrorAndOutput") ]]; then
+        cat <<EOF >>/etc/logstash/conf.d/weblogic-logs.conf
+   file {
+    path => "${wlsLogPath}/${serverName}.out"
+    codec => multiline {
+        pattern => "^<"
+        negate => true
+        what => "previous"
+    }
+    start_position => beginning
+   }
+EOF
+    fi
+
+    if [[ -n $(echo ${logsToIntegrate} | grep "NodeManagerLog") ]]; then
+        cat <<EOF >>/etc/logstash/conf.d/weblogic-logs.conf
+   file {
+    path => "${wlsDomainPath}/nodemanager/nodemanager.log"
+    codec => multiline {
+        pattern => "^<"
+        negate => true
+        what => "previous"
+    }
+    start_position => beginning
+   }
+EOF
+    fi
+
+    cat <<EOF >>/etc/logstash/conf.d/weblogic-logs.conf
+}
+filter {
+    grok {
+        match => {"path" => "%{GREEDYDATA}/%{GREEDYDATA:type}"}
+    }
+    mutate {
+        add_field => { "internal_ip" => "${privateIP}" }
+    }
+
+    if [type] == "${serverName}.log" {
+        mutate { replace => { type => "weblogic_server_log" } }
+        # match rid
+        grok {
+            patterns_dir=> ["/etc/logstash/patterns"]
+            match => [ "message", "####<%{WEBLOGICDOMAINDATE}%{SPACE}%{GREEDYDATA:log_timezone}>%{SPACE}<%{LOGLEVEL:log_severity}>%{SPACE}<%{GREEDYDATA:log_subSystem}>%{SPACE}<%{HOSTNAME:log_machine}>%{SPACE}<%{DATA:log_server}>%{SPACE}<%{DATA:log_thread}>%{SPACE}<%{DATA:log_userId}>%{SPACE}<%{DATA:log_transactionId}>%{SPACE}<%{DATA:log_contextId}>%{SPACE}<%{NUMBER:log_timestamp}>%{SPACE}<\[severity-value: %{INT:log_severityValue}\]%{WEBLOGICSERVERLOGPARTITION}>%{SPACE}<%{DATA:log_massageId}>%{SPACE}<%{WEBLOGICSERVERMESSAGE}>" ]
+        }
+
+        mutate { 
+            replace => ['log_date', '%{tmp_month} %{tmp_day}, %{tmp_year} %{tmp_hour}:%{tmp_min}:%{tmp_second},%{tmp_sss} %{tmp_aa}']
+        }
+
+        translate {
+            field       => 'log_timezone'
+            destination => 'log_timezone'
+            fallback => '%{log_timezone}'
+            override => "true"
+            dictionary  => {
+                "Coordinated Universal Time" => "UTC"
+            }
+        }
+
+        date {
+            match => [ "log_date", "MMM dd, YYYY KK:mm:ss,SSS aa", "MMM d, YYYY KK:mm:ss,SSS aa"]
+            timezone => "%{log_timezone}"
+            target => "log_date"
+        }
+        mutate {
+            remove_field => [ 'log_timezone', 'tmp_month', 'tmp_day', 'tmp_year', 'tmp_hour', 'tmp_min', 'tmp_second', 'tmp_sss', 'tmp_aa']
+        }
+    }
+    else if [type] == "access.log" {
+        # drop message starting with #
+        if [message] =~ /^#/ {
+            drop {}
+        }
+        mutate { replace => { type => "weblogic_access_log" } }
+        grok {
+            patterns_dir=> ["/etc/logstash/patterns"]
+            match => [ "message", "%{ACCESSDATE:acc_date}\s+%{TIME:acc_time}\s+%{NUMBER:time_taken}\s+%{NUMBER:bytes:int}\s+%{IP:c_ip}\s+%{HOSTPORT:s_ip}\s+%{IPORHOST:c_dns}\s+%{IPORHOST:s_dns}\s+%{WORD:cs_method}\s+%{URIPATHPARAM:cs_uri}\s+%{NUMBER:sc_status}\s+%{QUOTEDSTRING:sc-comment}\s+%{WORDNOSPACES:ctx-ecid}\s+%{WORDNOSPACES:ctx-rid}" ]
+        }
+        mutate { 
+            replace => ['acc_timestamp', '%{acc_date} %{acc_time}']
+        }
+        date {
+            match => [ "acc_timestamp" , "yyyy-MM-dd HH:mm:ss" ]
+            timezone => "UTC"
+            target => "acc_timestamp"
+        }
+        mutate {
+            remove_field => [ 'acc_date', 'acc_time']
+        }
+    }
+    else if [type] == "${wlsDomainName}.log" {
+      mutate { replace => { type => "weblogic_domain_log" } }
+        grok {
+            patterns_dir=> ["/etc/logstash/patterns"]
+            match => [ "message", "####<%{WEBLOGICDOMAINDATE}%{SPACE}%{GREEDYDATA:diag_timezone}>%{SPACE}<%{LOGLEVEL:diag_severity}>%{SPACE}<%{GREEDYDATA:diag_subSystem}>%{SPACE}<%{HOSTNAME:diag_machine}>%{SPACE}<%{HOSTNAME:diag_server}>%{SPACE}<%{DATA:diag_thread}>%{SPACE}<%{WORDNOBRACKET:diag_userId}>%{SPACE}<%{DATA:diag_transactionId}>%{SPACE}<%{WORDNOSPACES:diag_contextId}>%{SPACE}<%{NUMBER:diag_timestamp}>%{SPACE}<\[severity-value: %{INT:diag_severityValue}\]%{WEBLOGICLOGPARTITION}>%{SPACE}<%{DATA:diag_massageId}>%{SPACE}<%{WEBLOGICDIAGMESSAGE}>" ]
+        }
+
+        mutate { 
+            replace => ['diag_date', '%{tmp_month} %{tmp_day}, %{tmp_year} %{tmp_hour}:%{tmp_min}:%{tmp_second},%{tmp_sss} %{tmp_aa}']
+        }
+
+        translate {
+            field       => 'diag_timezone'
+            destination => 'diag_timezone'
+            fallback => '%{diag_timezone}'
+            override => "true"
+            dictionary  => {
+                "Coordinated Universal Time" => "UTC"
+            }
+        }
+
+        date {
+            match => [ "diag_date", "MMM dd, YYYY KK:mm:ss,SSS aa", "MMM d, YYYY KK:mm:ss,SSS aa"]
+            timezone => "%{diag_timezone}"
+            target => "diag_date"
+        }
+        mutate {
+            remove_field => [ 'diag_timezone', 'tmp_month', 'tmp_day', 'tmp_year', 'tmp_hour', 'tmp_min', 'tmp_second', 'tmp_sss', 'tmp_aa']
+        }
+    }
+    else if [type] == "datasource.log" {
+        mutate { replace => { type => "weblogic_datasource_log" } }
+        # with timestamp
+        grok {
+            patterns_dir=> ["/etc/logstash/patterns"]
+            match => [ "message", "####<%{WORDNOSPACES:ds_dataSource}>%{SPACE}<%{WORDNOSPACES:ds_profileType}>%{SPACE}<%{DSIDORTIMESTAMP}>%{SPACE}<%{DSWEBLOGICMESSAGE}>%{SPACE}<%{DATA:ds_info}>%{SPACE}<%{DSPARTITION}>" ]
+        }
+
+        if ([db_month]) {
+            # DBDATETIME %{DAY} %{MONTH:db_month} %{MONTHDAY:db_day} %{HOUR:db_hour}:%{MINUTE:db_minute}:%{SECOND:db_second} %{TZ:db_tz} %{YEAR:db_year}
+            mutate { 
+                replace => ["ds_timestamp", "%{db_month} %{db_day}, %{db_year} %{db_hour}:%{db_minute}:%{db_second}"]
+            }
+
+            date {
+                match => [ "ds_timestamp", "MMM dd, YYYY HH:mm:ss", "MMM  d, YYYY HH:mm:ss"]
+                timezone => "%{db_tz}"
+                target => "ds_timestamp"
+            }
+            mutate {
+                remove_field => [ 'db_month','db_day','db_year','db_hour','db_minute','db_second','db_tz']
+            }
+        }
+    }
+    else if [type] == "${serverName}.out" {
+        mutate { replace => { type => "weblogic_std_log" } }
+        grok {
+            patterns_dir=> ["/etc/logstash/patterns"]
+            match => [ "message", "<%{WEBLOGICSTDDATE}%{SPACE}%{WORDWITHSPACE:out_timezone}>%{SPACE}<%{WORDWITHSPACE:out_level}>%{SPACE}<%{WORDWITHSPACE:out_subsystem}>%{SPACE}%{WEBLOGICSTDDYNAMICID}"]
+        }
+        
+         mutate { 
+            replace => ['out_timestamp', '%{tmp_month} %{tmp_day}, %{tmp_year} %{tmp_hour}:%{tmp_min}:%{tmp_second} %{tmp_aa}']
+        }
+
+        # CEST id does not exist in JODA-TIME, changed to CET
+        translate {
+            field       => 'out_timezone'
+            destination => 'out_timezone'
+            fallback => '%{out_timezone}'
+            override => "true"
+            dictionary  => {
+                "CEST" => "CET"
+                "Coordinated Universal Time" => "UTC"
+            }
+        }
+        
+        date {
+            match => [ "out_timestamp", "MMM dd, YYYY KK:mm:ss aa", "MMM d, YYYY KK:mm:ss aa", "MMM dd, YYYY KK:mm:ss,SSS aa", "MMM d, YYYY KK:mm:ss,SSS aa"]
+            timezone => "%{out_timezone}"
+            target => "out_timestamp"
+        }
+        mutate {
+            remove_field => [ 'out_timezone','tmp_month', 'tmp_day', 'tmp_year', 'tmp_hour', 'tmp_min', 'tmp_second', 'tmp_aa']
+        }
+    }
+    else if [type] == "nodemanager.log" {
+        mutate { replace => { type => "weblogic_nodemanager_log" } }
+        grok {
+            patterns_dir=> ["/etc/logstash/patterns"]
+            match => [ "message", "<%{WEBLOGICSTDDATE}%{SPACE}%{WORDWITHSPACE:node_timezone}>%{SPACE}<%{WORDWITHSPACE:node_level}>%{SPACE}%{NODEMANAGEREND}"]
+        }
+        
+         mutate { 
+            replace => ['node_timestamp', '%{tmp_month} %{tmp_day}, %{tmp_year} %{tmp_hour}:%{tmp_min}:%{tmp_second} %{tmp_aa}']
+        }
+
+        # CEST id does not exist in JODA-TIME, changed to CET
+        translate {
+            field       => 'node_timezone'
+            destination => 'node_timezone'
+            fallback => '%{node_timezone}'
+            override => "true"
+            dictionary  => {
+                "CEST" => "CET"
+                "Coordinated Universal Time" => "UTC"
+            }
+        }
+        
+        date {
+            match => [ "node_timestamp", "MMM dd, YYYY KK:mm:ss aa", "MMM d, YYYY KK:mm:ss aa", "MMM dd, YYYY KK:mm:ss,SSS aa", "MMM d, YYYY KK:mm:ss,SSS aa"]
+            timezone => "%{node_timezone}"
+            target => "node_timestamp"
+        }
+        mutate {
+            remove_field => [ 'node_timezone','tmp_month', 'tmp_day', 'tmp_year', 'tmp_hour', 'tmp_min', 'tmp_second', 'tmp_aa']
+        }
+    }
+}
+output {
+    elasticsearch {
+        hosts => "${elasticURI}"
+        user => "${elasticUserName}"
+        password => "${elasticPassword}"
+        index => "${logIndex}"
+    }
+}
+EOF
+
+    # Add JAVA_HOME to startup.options
+    cp /etc/logstash/startup.options /etc/logstash/startup.options.elksave
+    sed -i -e "/JAVACMD/a\\JAVA_HOME=${JAVA_HOME}" /etc/logstash/startup.options
+    sed -i -e "s:LS_USER=.*:LS_USER=${userOracle}:g" /etc/logstash/startup.options
+    sed -i -e "s:LS_GROUP=.*:LS_GROUP=${groupOracle}:g" /etc/logstash/startup.options
+
+    # For Java 11
+    # ISSUE: https://github.com/elastic/logstash/issues/10496
+    java_version=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
+    if [ ${java_version:0:3} -ge 110 ]; then
+        cp /etc/logstash/jvm.options /etc/logstash/jvm.options.elksave
+        cat <<EOF >>/etc/logstash/jvm.options
+--add-opens java.base/sun.nio.ch=org.jruby.dist 
+--add-opens java.base/java.io=org.jruby.dist
+EOF
+    fi
+
+    # create start up for logstash
+    /usr/share/logstash/bin/system-install /etc/logstash/startup.options
+    if [ $? -ne 0 ]; then
+        echo_stderr "Failed to set up logstash service."
+        exit 1
+    fi
+
+    sudo chown -R ${userOracle}:${groupOracle} /var/lib/logstash
+    sudo chown -R ${userOracle}:${groupOracle} /etc/logstash
+}
+
+function configure_wls_log() {
+    echo "Configure WebLogic Log"
+    java $WLST_ARGS weblogic.WLST ${SCRIPT_PWD}/configure-wls-log.py
+
+    errorCode=$?
+    if [ $errorCode -eq 1 ]; then
+        echo "Exception occurs during ELK configuration, please check."
+        exit 1
+    fi
+}
+
+function setup_javahome() {
+    . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
+}
+
+function restart_admin_service() {
+    echo "Restart weblogic admin server"
+    echo "Stop admin server"
+    shutdown_admin
+    sudo systemctl start wls_admin
+    echo "Waiting for admin server to be available"
+    wait_for_admin
+    echo "Weblogic admin server is up and running"
+}
+
+function restartManagedServers() {
+    echo "Restart managed servers"
+    cat <<EOF >${SCRIPT_PWD}/restart-managedServer.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+servers=cmo.getServers()
+domainRuntime()
+print "Restart the servers which are in RUNNING status"
+for server in servers:
+    bean="/ServerLifeCycleRuntimes/"+server.getName()
+    serverbean=getMBean(bean)
+    if (serverbean.getState() in ("RUNNING")) and (server.getName() != '${wlsAdminServerName}'):
+        try:
+            print "Stop the Server ",server.getName()
+            shutdown(server.getName(),server.getType(),ignoreSessions='true',force='true')
+            print "Start the Server ",server.getName()
+            start(server.getName(),server.getType())
+        except:
+            print "Failed restarting managed server ", server.getName()
+            dumpStack()
+serverConfig()
+disconnect()
+EOF
+    . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
+    java $WLST_ARGS weblogic.WLST ${SCRIPT_PWD}/restart-managedServer.py
+
+    if [[ $? != 0 ]]; then
+        echo "Error : Fail to restart managed server to sync up elk configuration."
+        exit 1
+    fi
+}
+
+#This function to check admin server status
+function wait_for_admin() {
+    #check admin server status
+    count=1
+    export CHECK_URL="http://$wlsAdminURL/weblogic/ready"
+    status=$(curl --insecure -ILs $CHECK_URL | tac | grep -m1 HTTP/1.1 | awk {'print $2'})
+    echo "Check admin server status"
+    while [[ "$status" != "200" ]]; do
+        echo "."
+        count=$((count + 1))
+        if [ $count -le 30 ]; then
+            sleep 1m
+        else
+            echo "Error : Maximum attempts exceeded while checking admin server status"
+            exit 1
+        fi
+        status=$(curl --insecure -ILs $CHECK_URL | tac | grep -m1 HTTP/1.1 | awk {'print $2'})
+        if [ "$status" == "200" ]; then
+            echo "WebLogic Server is running..."
+            break
+        fi
+    done
+}
+
+# shutdown admin server
+function shutdown_admin() {
+    #check admin server status
+    count=1
+    export CHECK_URL="http://$wlsAdminURL/weblogic/ready"
+    status=$(curl --insecure -ILs $CHECK_URL | tac | grep -m1 HTTP/1.1 | awk {'print $2'})
+    echo "Check admin server status"
+    while [[ "$status" == "200" ]]; do
+        echo "."
+        count=$((count + 1))
+        sudo systemctl stop wls_admin
+        if [ $count -le 30 ]; then
+            sleep 1m
+        else
+            echo "Error : Maximum attempts exceeded while stopping admin server"
+            exit 1
+        fi
+        status=$(curl --insecure -ILs $CHECK_URL | tac | grep -m1 HTTP/1.1 | awk {'print $2'})
+        if [ -z ${status} ]; then
+            echo "WebLogic Server is stop..."
+            break
+        fi
+    done
+}
+
+function cleanup() {
+    echo "Cleaning up temporary files..."
+    rm -f ${SCRIPT_PWD}/*.py
+    echo "Cleanup completed."
+}
+
+# main script starts from here
+
+export SCRIPT_PWD=$(pwd)
+
+# store arguments in a special array
+args=("$@")
+# get number of elements
+ELEMENTS=${#args[@]}
+
+# echo each element in array
+# for loop
+for ((i = 0; i < $ELEMENTS; i++)); do
+    echo "ARG[${args[${i}]}]"
+done
+
+export oracleHome=$1
+export wlsAdminURL=$2
+export wlsUserName=$3
+export wlsPassword=$4
+export wlsAdminServerName=$5
+export elasticURI=$6
+export elasticUserName=$7
+export elasticPassword=$8
+export wlsDomainName=$9
+export wlsDomainPath=${10}
+export logsToIntegrate=${11}
+export index=${12}
+export logIndex=${13}
+export managedServerPrefix=${14}
+
+export hostName=$(hostname)
+export userOracle="oracle"
+export groupOracle="oracle"
+
+if [ $# -ne 14 ]; then
+    usage
+    exit 1
+fi
+
+validate_input
+
+echo "start to configure ELK"
+setup_javahome
+
+if [ $index -eq 0 ]; then
+    create_wls_log_model
+    configure_wls_log
+    restart_admin_service
+    restartManagedServers
+fi
+
+remove_logstash
+install_logstash
+configure_lostash
+start_logstash
+cleanup

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/elkIntegrationForDynamicCluster.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/elkIntegrationForDynamicCluster.sh
@@ -7,7 +7,7 @@ function echo_stderr() {
 
 #Function to display usage message
 function usage() {
-    echo_stderr "./elkIntegration.sh <oracleHome> <wlsAdminURL> <managedServerPrefix> <wlsUserName> <wlsPassword> <wlsAdminServerName> <elasticURI> <elasticUserName> <elasticPassword> <wlsDomainName> <wlsDomainPath> <logsToIntegrate> <index> <logIndex> <maxDynamicClusterSize>"
+    echo_stderr "./elkIntegrationForDynamicCluster.sh <oracleHome> <wlsAdminURL> <managedServerPrefix> <wlsUserName> <wlsPassword> <wlsAdminServerName> <elasticURI> <elasticUserName> <elasticPassword> <wlsDomainName> <wlsDomainPath> <logsToIntegrate> <index> <logIndex> <maxDynamicClusterSize>"
 }
 
 function validate_input() {

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupCoherence.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupCoherence.sh
@@ -7,7 +7,7 @@ function echo_stderr() {
 
 #Function to display usage message
 function usage() {
-    echo_stderr "./setupCoherence.sh <wlsDomainName> <wlsUserName> <wlsPassword> <wlsServerName> <adminVMName> <oracleHome> <wlsDomainPath> <storageAccountName> <storageAccountKey> <mountpointPath> <enableWebLocalStorage>"
+    echo_stderr "./setupCoherence.sh <wlsDomainName> <wlsUserName> <wlsPassword> <wlsServerName> <adminVMName> <oracleHome> <wlsDomainPath> <storageAccountName> <storageAccountKey> <mountpointPath> <enableWebLocalStorage> <enableELK> <elasticURI> <elasticUserName> <elasticPassword> <logsToIntegrate> <logIndex> <managedServerPrefix> <serverIndex>"
 }
 
 function installUtilities() {
@@ -69,6 +69,38 @@ function validateInput() {
 
     if [ -z "$enableWebLocalStorage" ]; then
         echo_stderr "enableWebLocalStorage is required. "
+    fi
+
+    if [ -z "$enableELK" ]; then
+        echo_stderr "enableELK is required. "
+    fi
+
+    if [ -z "$elasticURI" ]; then
+        echo_stderr "elasticURI is required. "
+    fi
+
+    if [ -z "$elasticUserName" ]; then
+        echo_stderr "elasticUserName is required. "
+    fi
+
+    if [ -z "$elasticPassword" ]; then
+        echo_stderr "elasticPassword is required. "
+    fi
+
+    if [ -z "$logsToIntegrate" ]; then
+        echo_stderr "logsToIntegrate is required. "
+    fi
+
+    if [ -z "$logIndex" ]; then
+        echo_stderr "logIndex is required. "
+    fi
+
+    if [ -z "$serverIndex" ]; then
+        echo_stderr "serverIndex is required. "
+    fi
+
+    if [ -z "$managedServerPrefix" ]; then
+        echo_stderr "managedServerPrefix is required. "
     fi
 }
 
@@ -441,7 +473,7 @@ for ((i = 0; i < $ELEMENTS; i++)); do
     echo "ARG[${args[${i}]}]"
 done
 
-if [ $# -ne 11 ]; then
+if [ $# -ne 18 ]; then
     usage
     exit 1
 fi
@@ -449,14 +481,21 @@ fi
 export wlsDomainName=$1
 export wlsUserName=$2
 export wlsPassword=$3
-export wlsServerName=$4
-export adminVMName=$5
-export oracleHome=$6
-export wlsDomainPath=$7
-export storageAccountName=$8
-export storageAccountKey=$9
-export mountpointPath=${10}
-export enableWebLocalStorage=${11}
+export adminVMName=$4
+export oracleHome=$5
+export wlsDomainPath=$6
+export storageAccountName=$7
+export storageAccountKey=$8
+export mountpointPath=$9
+export enableWebLocalStorage=${10}
+export enableELK=${11}
+export elasticURI=${12}
+export elasticUserName=${13}
+export elasticPassword=${14}
+export logsToIntegrate=${15}
+export logIndex=${16}
+export managedServerPrefix=${17}
+export serverIndex=${18}
 
 export clientClusterName="cluster1"
 export coherenceClusterName="myCoherence"
@@ -474,11 +513,18 @@ export wlsAdminURL="${adminVMName}:7001"
 export wlsCoherenceUnicastPortRange="-Dcoherence.localport=$coherenceLocalport -Dcoherence.localport.adjust=$coherenceLocalportAdjust"
 export wlsServerTemplate="myServerTemplate"
 
+if [ ${serverIndex} -eq 0 ]; then
+    wlsServerName="admin"
+else
+    wlsServerName="${managedServerPrefix}${serverIndex}"
+fi
+
 validateInput
 cleanup
 
 if [ $wlsServerName == "admin" ]; then
     createCoherenceClusterModel
+    cleanup
 else
     installUtilities
     mountFileShare
@@ -488,6 +534,26 @@ else
     createNodeManagerService
     enabledAndStartNodeManagerService
     startManagedServer
-fi
+    cleanup
 
-cleanup
+    echo "enable ELK? ${enableELK}"
+    chmod ugo+x ${SCRIPT_PWD}/elkIntegrationForConfiguredCluster.sh
+    if [[ "${enableELK,,}" == "true" ]]; then
+        echo "Set up ELK..."
+        ${SCRIPT_PWD}/elkIntegrationForConfiguredCluster.sh \
+            ${oracleHome} \
+            ${wlsAdminURL} \
+            ${wlsUserName} \
+            ${wlsPassword} \
+            "admin" \
+            ${elasticURI} \
+            ${elasticUserName} \
+            ${elasticPassword} \
+            ${wlsDomainName} \
+            ${wlsDomainPath}/${wlsDomainName} \
+            ${logsToIntegrate} \
+            ${serverIndex} \
+            ${logIndex} \
+            ${managedServerPrefix}
+    fi
+fi

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupCoherence.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupCoherence.sh
@@ -1,0 +1,493 @@
+#!/bin/bash
+
+#Function to output message to StdErr
+function echo_stderr() {
+    echo "$@" >&2
+}
+
+#Function to display usage message
+function usage() {
+    echo_stderr "./setupCoherence.sh <wlsDomainName> <wlsUserName> <wlsPassword> <wlsServerName> <adminVMName> <oracleHome> <wlsDomainPath> <storageAccountName> <storageAccountKey> <mountpointPath> <enableWebLocalStorage>"
+}
+
+function installUtilities() {
+    echo "Installing zip unzip wget vnc-server rng-tools cifs-utils"
+    sudo yum install -y zip unzip wget vnc-server rng-tools cifs-utils
+
+    #Setting up rngd utils
+    attempt=1
+    while [[ $attempt -lt 4 ]]; do
+        echo "Starting rngd service attempt $attempt"
+        sudo systemctl start rngd
+        attempt=$(expr $attempt + 1)
+        sudo systemctl status rngd | grep running
+        if [[ $? == 0 ]]; then
+            echo "rngd utility service started successfully"
+            break
+        fi
+        sleep 1m
+    done
+}
+
+function validateInput() {
+    if [ -z "$wlsDomainName" ]; then
+        echo_stderr "wlsDomainName is required. "
+    fi
+
+    if [[ -z "$wlsUserName" || -z "$wlsPassword" ]]; then
+        echo_stderr "wlsUserName or wlsPassword is required. "
+        exit 1
+    fi
+
+    if [ -z "$wlsServerName" ]; then
+        echo_stderr "wlsServerName is required. "
+    fi
+
+    if [ -z "$adminVMName" ]; then
+        echo_stderr "adminVMName is required. "
+    fi
+
+    if [ -z "$oracleHome" ]; then
+        echo_stderr "oracleHome is required. "
+    fi
+
+    if [ -z "$wlsDomainPath" ]; then
+        echo_stderr "wlsDomainPath is required. "
+    fi
+
+    if [ -z "$storageAccountName" ]; then
+        echo_stderr "storageAccountName is required. "
+    fi
+
+    if [ -z "$storageAccountKey" ]; then
+        echo_stderr "storageAccountKey is required. "
+    fi
+
+    if [ -z "$mountpointPath" ]; then
+        echo_stderr "mountpointPath is required. "
+    fi
+
+    if [ -z "$enableWebLocalStorage" ]; then
+        echo_stderr "enableWebLocalStorage is required. "
+    fi
+}
+
+#run on admin server
+#create coherence cluster
+#associate cluster1 with the coherence cluster
+#create configured cluter storage1 and enable local storage
+#associate storage1 with the coherence cluster
+function createCoherenceClusterModel() {
+    cat <<EOF >$wlsDomainPath/configure-coherence-cluster.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+shutdown('$clientClusterName', 'Cluster')
+try:
+    edit()
+    startEdit()
+    cd('/')
+    cmo.createCoherenceClusterSystemResource('${coherenceClusterName}')
+
+    cd('/CoherenceClusterSystemResources/${coherenceClusterName}/CoherenceClusterResource/${coherenceClusterName}/CoherenceClusterParams/${coherenceClusterName}')
+    cmo.setClusteringMode('unicast')
+    cmo.setClusterListenPort(${coherenceListenPort})
+
+    cd('/')
+    cmo.createCluster('${storageClusterName}')
+
+    cd('/Clusters/${storageClusterName}')
+    cmo.setClusterMessagingMode('unicast')
+    cmo.setCoherenceClusterSystemResource(getMBean('/CoherenceClusterSystemResources/${coherenceClusterName}'))
+
+    cd('/Clusters/${clientClusterName}')
+    cmo.setCoherenceClusterSystemResource(getMBean('/CoherenceClusterSystemResources/${coherenceClusterName}'))
+
+    cd('/CoherenceClusterSystemResources/${coherenceClusterName}')
+    cmo.addTarget(getMBean('/Clusters/${storageClusterName}'))
+    cmo.addTarget(getMBean('/Clusters/${clientClusterName}'))
+
+    cd('/Clusters/${storageClusterName}/CoherenceTier/${storageClusterName}')
+    cmo.setCoherenceWebLocalStorageEnabled(${enableWebLocalStorage})
+    cmo.setLocalStorageEnabled(true)
+
+    cd('/Clusters/${clientClusterName}/CoherenceTier/${clientClusterName}')
+    cmo.setLocalStorageEnabled(false)
+
+    cd('/ServerTemplates/${wlsServerTemplate}//ServerStart/${wlsServerTemplate}')
+    arguments = cmo.getArguments()
+    if(str(arguments) == 'None'):
+        arguments = '${wlsCoherenceUnicastPortRange}'
+    else:
+        arguments = str(arguments) + ' ' + '${wlsCoherenceUnicastPortRange}'
+    cmo.setArguments(arguments)
+
+    save()
+    activate()
+except:
+    stopEdit('y')
+    sys.exit(1)
+
+try: 
+    start('$clientClusterName', 'Cluster')
+except:
+    dumpStack()
+
+disconnect()
+sys.exit(0)
+EOF
+
+    runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; java $WLST_ARGS weblogic.WLST $wlsDomainPath/configure-coherence-cluster.py"
+    if [[ $? != 0 ]]; then
+        echo "Error : Create coherence cluster ${coherenceClusterName} failed"
+        exit 1
+    fi
+}
+
+#Creates weblogic deployment model for cluster domain managed server
+function create_managed_model() {
+    echo "Creating admin domain model"
+    cat <<EOF >$wlsDomainPath/managed-domain.yaml
+domainInfo:
+   AdminUserName: "$wlsUserName"
+   AdminPassword: "$wlsPassword"
+   ServerStartMode: prod
+topology:
+   Name: "$wlsDomainName"
+   Machine:
+     '$nmHost':
+         NodeManager:
+             ListenAddress: "$nmHost"
+             ListenPort: $nmPort
+             NMType : ssl  
+   Cluster:
+        '$storageClusterName':
+            MigrationBasis: 'database'
+   Server:
+        '$wlsServerName' :
+           ListenPort: $storageListenPort
+           Notes: "$wlsServerName managed server"
+           Cluster: "$storageClusterName"
+           Machine: "$nmHost"
+   SecurityConfiguration:
+       NodeManagerUsername: "$wlsUserName"
+       NodeManagerPasswordEncrypted: "$wlsPassword" 
+EOF
+}
+
+#This function to add machine for a given managed server
+function create_machine_model() {
+    echo "Creating machine name model for managed server $wlsServerName"
+    cat <<EOF >$wlsDomainPath/add-machine.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+edit("$wlsServerName")
+startEdit()
+cd('/')
+cmo.createMachine('$nmHost')
+cd('/Machines/$nmHost/NodeManager/$nmHost')
+cmo.setListenPort(int($nmPort))
+cmo.setListenAddress('$nmHost')
+cmo.setNMType('ssl')
+save()
+resolve()
+activate()
+destroyEditSession("$wlsServerName")
+disconnect()
+EOF
+}
+
+#This function to add managed serverto admin node
+function create_ms_server_model() {
+    echo "Creating managed server $wlsServerName model"
+    cat <<EOF >$wlsDomainPath/add-server.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+edit("$wlsServerName")
+startEdit()
+cd('/')
+cmo.createServer('$wlsServerName')
+cd('/Servers/$wlsServerName')
+cmo.setMachine(getMBean('/Machines/$nmHost'))
+cmo.setCluster(getMBean('/Clusters/$storageClusterName'))
+cmo.setListenAddress('$nmHost')
+cmo.setListenPort(int($storageListenPort))
+cmo.setListenPortEnabled(true)
+cd('/Servers/$wlsServerName/SSL/$wlsServerName')
+cmo.setEnabled(false)
+cd('/Servers/$wlsServerName//ServerStart/$wlsServerName')
+arguments = '-Dweblogic.Name=$wlsServerName  -Dweblogic.management.server=http://$wlsAdminURL ${wlsCoherenceUnicastPortRange}'
+cmo.setArguments(arguments)
+save()
+resolve()
+activate()
+destroyEditSession("$wlsServerName")
+nmEnroll('$wlsDomainPath/$wlsDomainName','$wlsDomainPath/$wlsDomainName/nodemanager')
+nmGenBootStartupProps('$wlsServerName')
+disconnect()
+EOF
+}
+
+#This function to check admin server status
+function wait_for_admin() {
+    #check admin server status
+    count=1
+    export CHECK_URL="http://$wlsAdminURL/weblogic/ready"
+    status=$(curl --insecure -ILs $CHECK_URL | tac | grep -m1 HTTP/1.1 | awk {'print $2'})
+    echo "Check admin server status"
+    while [[ "$status" != "200" ]]; do
+        echo "."
+        count=$((count + 1))
+        if [ $count -le 30 ]; then
+            sleep 1m
+        else
+            echo "Error : Maximum attempts exceeded while checking admin server status"
+            exit 1
+        fi
+        status=$(curl --insecure -ILs $CHECK_URL | tac | grep -m1 HTTP/1.1 | awk {'print $2'})
+        if [ "$status" == "200" ]; then
+            echo "WebLogic Server is running..."
+            break
+        fi
+    done
+}
+
+# Create systemctl service for nodemanager
+function createNodeManagerService() {
+    echo "Setting CrashRecoveryEnabled true at $wlsDomainPath/$wlsDomainName/nodemanager/nodemanager.properties"
+    sed -i.bak -e 's/CrashRecoveryEnabled=false/CrashRecoveryEnabled=true/g' $wlsDomainPath/$wlsDomainName/nodemanager/nodemanager.properties
+    if [ $? != 0 ]; then
+        echo "Warning : Failed in setting option CrashRecoveryEnabled=true. Continuing without the option."
+        mv $wlsDomainPath/nodemanager/nodemanager.properties.bak $wlsDomainPath/$wlsDomainName/nodemanager/nodemanager.properties
+    fi
+    sudo chown -R $username:$groupname $wlsDomainPath/$wlsDomainName/nodemanager/nodemanager.properties*
+    echo "Creating NodeManager service"
+    cat <<EOF >/etc/systemd/system/wls_nodemanager.service
+ [Unit]
+Description=WebLogic nodemanager service
+ 
+[Service]
+Type=simple
+# Note that the following three parameters should be changed to the correct paths
+# on your own system
+WorkingDirectory="$wlsDomainPath/$wlsDomainName"
+ExecStart="$wlsDomainPath/$wlsDomainName/bin/startNodeManager.sh"
+ExecStop="$wlsDomainPath/$wlsDomainName/bin/stopNodeManager.sh"
+User=oracle
+Group=oracle
+KillMode=process
+LimitNOFILE=65535
+ 
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+#This function to start managed server
+function startManagedServer() {
+    echo "Starting managed server $wlsServerName"
+    cat <<EOF >$wlsDomainPath/start-server.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+try:
+   start('$wlsServerName', 'Server')
+except:
+   print "Failed starting managed server $wlsServerName"
+   dumpStack()
+disconnect()
+EOF
+    sudo chown -R $username:$groupname $wlsDomainPath
+    runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; java $WLST_ARGS weblogic.WLST $wlsDomainPath/start-server.py"
+    if [[ $? != 0 ]]; then
+        echo "Error : Failed in starting managed server $wlsServerName"
+        exit 1
+    fi
+}
+
+# Create managed server setup
+function createManagedSetup() {
+    echo "Creating Managed Server Setup"
+    cd $wlsDomainPath
+    wget -q $weblogicDeployTool
+    if [[ $? != 0 ]]; then
+        echo "Error : Downloading weblogic-deploy-tool failed"
+        exit 1
+    fi
+    sudo unzip -o weblogic-deploy.zip -d $wlsDomainPath
+    echo "Creating managed server model files"
+    create_managed_model
+    create_machine_model
+    create_ms_server_model
+    echo "Completed managed server model files"
+    sudo chown -R $username:$groupname $wlsDomainPath
+    runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; $wlsDomainPath/weblogic-deploy/bin/createDomain.sh -oracle_home $oracleHome -domain_parent $wlsDomainPath  -domain_type WLS -model_file $wlsDomainPath/managed-domain.yaml"
+    if [[ $? != 0 ]]; then
+        echo "Error : Managed setup failed"
+        exit 1
+    fi
+    wait_for_admin
+
+    # For issue https://github.com/wls-eng/arm-oraclelinux-wls/issues/89
+    getSerializedSystemIniFileFromShare
+
+    echo "Adding machine to managed server $wlsServerName"
+    runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; java $WLST_ARGS weblogic.WLST $wlsDomainPath/add-machine.py"
+    if [[ $? != 0 ]]; then
+        echo "Error : Adding machine for managed server $wlsServerName failed"
+        exit 1
+    fi
+    echo "Adding managed server $wlsServerName"
+    runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; java $WLST_ARGS weblogic.WLST $wlsDomainPath/add-server.py"
+    if [[ $? != 0 ]]; then
+        echo "Error : Adding server $wlsServerName failed"
+        exit 1
+    fi
+}
+
+function enabledAndStartNodeManagerService() {
+    sudo systemctl enable wls_nodemanager
+    sudo systemctl daemon-reload
+    attempt=1
+    while [[ $attempt -lt 6 ]]; do
+        echo "Starting nodemanager service attempt $attempt"
+        sudo systemctl start wls_nodemanager
+        attempt=$(expr $attempt + 1)
+        sudo systemctl status wls_nodemanager | grep running
+        if [[ $? == 0 ]]; then
+            echo "wls_nodemanager service started successfully"
+            break
+        fi
+        sleep 3m
+    done
+}
+
+function cleanup() {
+    echo "Cleaning up temporary files..."
+    rm -rf $wlsDomainPath/managed-domain.yaml
+    rm -rf $wlsDomainPath/weblogic-deploy.zip
+    rm -rf $wlsDomainPath/weblogic-deploy
+    rm -rf $wlsDomainPath/*.py
+    echo "Cleanup completed."
+}
+
+function openPortsForCoherence() {
+    # for Oracle Linux 7.3, 7.4, iptable is not running.
+    if [ -z $(command -v firewall-cmd) ]; then
+        return 0
+    fi
+
+    # for Oracle Linux 7.6, open weblogic ports
+    echo "update network rules for managed server"
+    sudo firewall-cmd --zone=public --add-port=$coherenceListenPort/tcp
+    sudo firewall-cmd --zone=public --add-port=$coherenceListenPort/udp
+    sudo firewall-cmd --zone=public --add-port=$storageListenPort/tcp
+
+    sudo firewall-cmd --zone=public --add-port=$coherenceLocalport-$coherenceLocalportAdjust/tcp
+    sudo firewall-cmd --zone=public --add-port=$coherenceLocalport-$coherenceLocalportAdjust/udp
+    # Coherence TcpRing/IpMonitor  port 7
+    sudo firewall-cmd --zone=public --add-port=7/tcp
+    sudo firewall-cmd --zone=public --add-port=$nmPort/tcp
+
+    sudo firewall-cmd --runtime-to-permanent
+    sudo systemctl restart firewalld
+}
+
+# Mount the Azure file share on all VMs created
+function mountFileShare() {
+    echo "Creating mount point"
+    echo "Mount point: $mountpointPath"
+    sudo mkdir -p $mountpointPath
+    if [ ! -d "/etc/smbcredentials" ]; then
+        sudo mkdir /etc/smbcredentials
+    fi
+    if [ ! -f "/etc/smbcredentials/${storageAccountName}.cred" ]; then
+        echo "Crearing smbcredentials"
+        echo "username=$storageAccountName >> /etc/smbcredentials/${storageAccountName}.cred"
+        echo "password=$storageAccountKey >> /etc/smbcredentials/${storageAccountName}.cred"
+        sudo bash -c "echo "username=$storageAccountName" >> /etc/smbcredentials/${storageAccountName}.cred"
+        sudo bash -c "echo "password=$storageAccountKey" >> /etc/smbcredentials/${storageAccountName}.cred"
+    fi
+    echo "chmod 600 /etc/smbcredentials/${storageAccountName}.cred"
+    sudo chmod 600 /etc/smbcredentials/${storageAccountName}.cred
+    echo "//${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred ,dir_mode=0777,file_mode=0777,serverino"
+    sudo bash -c "echo \"//${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred ,dir_mode=0777,file_mode=0777,serverino\" >> /etc/fstab"
+    echo "mount -t cifs //${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino"
+    sudo mount -t cifs //${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
+    if [[ $? != 0 ]]; then
+        echo "Failed to mount //${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath"
+        exit 1
+    fi
+}
+
+# Get SerializedSystemIni.dat file from share point to managed server vm
+function getSerializedSystemIniFileFromShare() {
+    runuser -l oracle -c "mv ${wlsDomainPath}/${wlsDomainName}/security/SerializedSystemIni.dat ${wlsDomainPath}/${wlsDomainName}/security/SerializedSystemIni.dat.backup"
+    runuser -l oracle -c "cp ${mountpointPath}/SerializedSystemIni.dat ${wlsDomainPath}/${wlsDomainName}/security/."
+    ls -lt ${wlsDomainPath}/${wlsDomainName}/security/SerializedSystemIni.dat
+    if [[ $? != 0 ]]; then
+        echo "Failed to get ${mountpointPath}/SerializedSystemIni.dat"
+        exit 1
+    fi
+    runuser -l oracle -c "chmod 640 ${wlsDomainPath}/${wlsDomainName}/security/SerializedSystemIni.dat"
+}
+
+# main script starts from here
+
+export SCRIPT_PWD=$(pwd)
+
+# store arguments in a special array
+args=("$@")
+# get number of elements
+ELEMENTS=${#args[@]}
+
+# echo each element in array
+# for loop
+for ((i = 0; i < $ELEMENTS; i++)); do
+    echo "ARG[${args[${i}]}]"
+done
+
+if [ $# -ne 11 ]; then
+    usage
+    exit 1
+fi
+
+export wlsDomainName=$1
+export wlsUserName=$2
+export wlsPassword=$3
+export wlsServerName=$4
+export adminVMName=$5
+export oracleHome=$6
+export wlsDomainPath=$7
+export storageAccountName=$8
+export storageAccountKey=$9
+export mountpointPath=${10}
+export enableWebLocalStorage=${11}
+
+export clientClusterName="cluster1"
+export coherenceClusterName="myCoherence"
+export coherenceListenPort=7574
+export coherenceLocalport=42000
+export coherenceLocalportAdjust=42200
+export groupname="oracle"
+export nmHost=$(hostname)
+export nmPort=5556
+export storageClusterName="storage1"
+export storageListenPort=7501
+export weblogicDeployTool=https://github.com/oracle/weblogic-deploy-tooling/releases/download/weblogic-deploy-tooling-1.8.1/weblogic-deploy.zip
+export username="oracle"
+export wlsAdminURL="${adminVMName}:7001"
+export wlsCoherenceUnicastPortRange="-Dcoherence.localport=$coherenceLocalport -Dcoherence.localport.adjust=$coherenceLocalportAdjust"
+export wlsServerTemplate="myServerTemplate"
+
+validateInput
+cleanup
+
+if [ $wlsServerName == "admin" ]; then
+    createCoherenceClusterModel
+else
+    installUtilities
+    mountFileShare
+    openPortsForCoherence
+    updateNetworkRules
+    createManagedSetup
+    createNodeManagerService
+    enabledAndStartNodeManagerService
+    startManagedServer
+fi
+
+cleanup

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
@@ -524,6 +524,13 @@ function updateNetworkRules()
           sudo firewall-cmd --zone=public --add-port=$managedPort/tcp
           maxManagedIndex=$(($maxManagedIndex + 1))
         done
+
+        # open ports for coherence
+        sudo firewall-cmd --zone=public --add-port=$coherenceListenPort/tcp
+        sudo firewall-cmd --zone=public --add-port=$coherenceListenPort/udp
+        sudo firewall-cmd --zone=public --add-port=$coherenceLocalport-$coherenceLocalportAdjust/tcp
+        sudo firewall-cmd --zone=public --add-port=$coherenceLocalport-$coherenceLocalportAdjust/udp
+        sudo firewall-cmd --zone=public --add-port=7/tcp
         
         sudo firewall-cmd --zone=public --add-port=$nmPort/tcp
     fi
@@ -645,6 +652,9 @@ export startWebLogicScript="${DOMAIN_PATH}/${wlsDomainName}/startWebLogic.sh"
 export stopWebLogicScript="${DOMAIN_PATH}/${wlsDomainName}/bin/customStopWebLogic.sh"
 
 # Always index 0 is set as admin server
+export coherenceListenPort=7574
+export coherenceLocalport=42000
+export coherenceLocalportAdjust=42200
 export wlsAdminPort=7001
 export wlsSSLAdminPort=7002
 export wlsManagedPort=8001

--- a/deletenode/src/main/arm/mainTemplate.json
+++ b/deletenode/src/main/arm/mainTemplate.json
@@ -23,10 +23,24 @@
                 "description": "Admin Server hosting VM name."
             }
         },
+        "deletingCacheServerNames": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Names of cache servers to be deleted, comma delimited. Please ignore this parameter if you are not deleting cache servers."
+            }
+        },
         "deletingManagedServerMachineNames": {
             "type": "array",
             "metadata": {
                 "description": "Vitual Machine names of managed servers to be deleted, comma delimited."
+            }
+        },
+        "managedServerPrefix": {
+            "type": "string",
+            "defaultValue": "msp",
+            "metadata": {
+                "description": "Provide managed server prefix name"
             }
         },
         "wlsUserName": {
@@ -116,7 +130,7 @@
                     ]
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('sh',' ', variables('name_scriptDeleteNode'), ' ', parameters('wlsUserName'),' ',parameters('wlsPassword'),' ', array.join(parameters('deletingManagedServerMachineNames')),' ', parameters('wlsForceShutDown'), ' ', parameters('adminVMName'), ' ',variables('const_wlsAdminPort'),' ',variables('const_wlsHome'))]"
+                    "commandToExecute": "[concat('sh',' ', variables('name_scriptDeleteNode'), ' ', parameters('wlsUserName'),' ',parameters('wlsPassword'),' ', array.join(parameters('deletingManagedServerMachineNames')),' ', parameters('wlsForceShutDown'), ' ', parameters('adminVMName'), ' ',variables('const_wlsAdminPort'),' ',variables('const_wlsHome'), ' ', parameters('managedServerPrefix'), ' ', array.join(parameters('deletingCacheServerNames')))]"
                 }
             }
         },

--- a/deletenode/src/main/scripts/deletenode.sh
+++ b/deletenode/src/main/scripts/deletenode.sh
@@ -9,7 +9,7 @@ function echo_stderr ()
 #Function to display usage message
 function usage()
 {
-  echo_stderr "./deletenode.sh <wlsUserName> <wlsPassword> <managedServerNames> <managedVMNames> <forceShutDown> <wlsAdminHost> <wlsAdminPort> <oracleHome>"
+  echo_stderr "./deletenode.sh <wlsUserName> <wlsPassword> <managedVMNames> <forceShutDown> <wlsAdminHost> <wlsAdminPort> <oracleHome> <managedServerPrefix> <deletingCacheServerNames>"
 }
 
 function validateInput()
@@ -18,11 +18,6 @@ function validateInput()
     then
         echo_stderr "wlsUserName or wlsPassword is required. "
         exit 1
-    fi	
-
-    if [ -z "$managedServerNames" ];
-    then
-        echo_stderr "managedServerNames is required. "
     fi
 
     if [ -z "$managedVMNames" ];
@@ -49,51 +44,91 @@ function validateInput()
     then
         echo_stderr "oracleHome is required. "
     fi
+
+    if [ -z "$managedServerPrefix" ];
+    then
+        echo_stderr "managedServerPrefix is required. "
+    fi
+
+    if [ -z "$deletingCacheServerNames" ];
+    then
+        echo_stderr "deletingCacheServerNames is required. "
+    fi
 }
 
 #Function to cleanup all temporary files
 function cleanup()
 {
     echo "Cleaning up temporary files..."
-    rm -f delete-machine.py
+    rm -f ${wlsDomainsPath}/*.py
     echo "Cleanup completed."
 }
 
 #This function to delete machines
 function delete_machine_model()
 {
+    arrServerMachineNames=$(echo $managedVMNames | tr "," "\n")
+    hasClient="false" # if there is client machine, have to shutdown and start cluster1
+    for machine in $arrServerMachineNames
+    do
+        if [[ "${machine}" =~ ^${managedServerPrefix}StorageVM[0-9]+$ ]];
+        then 
+            continue
+        else
+            hasClient="true"
+            break
+        fi
+    done
+    
     echo "Deleting managed server machine name model for $managedVMNames"
-    cat <<EOF >delete-machine.py
+    cat <<EOF >${wlsDomainsPath}/delete-machine.py
 connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
-shutdown('$wlsClusterName', 'Cluster')
 try:
     edit()
     startEdit()
 EOF
 
-    arrServerMachineNames=$(echo $managedVMNames | tr "," "\n")
+    if [[ "${hasClient}" == "true" ]]; then 
+    cat <<EOF >>${wlsDomainsPath}/delete-machine.py
+    shutdown('$wlsClusterName', 'Cluster')
+EOF
+    fi
+
     for machine in $arrServerMachineNames
     do
-        machineName="machine-"${machine}
+        if [[ -n ${managedServerPrefix} && "${machine}" =~ ^${managedServerPrefix}StorageVM[0-9]+$ ]];
+        then 
+            # machine name of cache machine
+            machineName=${machine}
+        else
+            # machine name of application machine
+            machineName="machine-"${machine}
+        fi
         echo "deleting name model for ${machineName}"
-        cat <<EOF >>delete-machine.py
+        cat <<EOF >>${wlsDomainsPath}/delete-machine.py
     editService.getConfigurationManager().removeReferencesToBean(getMBean('/Machines/${machineName}'))
     cmo.destroyMachine(getMBean('/Machines/${machineName}'))
 EOF
     done
 
-    cat <<EOF >>delete-machine.py
+    cat <<EOF >>${wlsDomainsPath}/delete-machine.py
     save()
     activate()
 except:
     stopEdit('y')
     sys.exit(1)
+EOF
 
+    if [[ "${hasClient}" == "true" ]]; then
+    cat <<EOF >>${wlsDomainsPath}/delete-machine.py
 try: 
     start('$wlsClusterName', 'Cluster')
 except:
     dumpStack()
-    
+EOF
+    fi
+
+    cat <<EOF >>${wlsDomainsPath}/delete-machine.py
 disconnect()
 EOF
 }
@@ -126,22 +161,87 @@ function wait_for_admin()
     done  
 }
 
-function delete_managed_server_node()
+function delete_cache_server()
+{
+    if [[ -z "$deletingCacheServerNames" || "$deletingCacheServerNames" == "[]" ]]; then
+        return
+    fi
+
+    echo "Deleting managed server name model for $deletingCacheServerNames"
+    cat <<EOF >${wlsDomainsPath}/delete-server.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+try:
+    edit()
+    startEdit()
+EOF
+
+arrCacheServerNames=$(echo $deletingCacheServerNames | tr "," "\n")
+for server in $arrCacheServerNames
+do
+    echo "deleting name model for $server"
+    cat <<EOF >>${wlsDomainsPath}/delete-server.py
+    shutdown('$server', 'Server',ignoreSessions='true',force='$wlsForceShutDown')
+    editService.getConfigurationManager().removeReferencesToBean(getMBean('/MigratableTargets/$server (migratable)'))
+    cd('/')
+    cmo.destroyMigratableTarget(getMBean('/MigratableTargets/$server (migratable)'))
+    cd('/Servers/$server')
+    cmo.setCluster(None)
+    cmo.setMachine(None)
+    editService.getConfigurationManager().removeReferencesToBean(getMBean('/Servers/$server'))
+    cd('/')
+    cmo.destroyServer(getMBean('/Servers/$server'))
+EOF
+done
+
+cat <<EOF >>${wlsDomainsPath}/delete-server.py
+    save()
+    activate()
+except:
+    stopEdit('y')
+    sys.exit(1)
+   
+disconnect()
+EOF
+
+    . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
+
+    echo "Start to delete managed server $deletingCacheServerNames"
+    sudo chown -R ${username}:${groupname} ${wlsDomainsPath}
+    runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; java $WLST_ARGS weblogic.WLST ${wlsDomainsPath}/delete-server.py"
+    if [[ $? != 0 ]]; then
+            echo "Error : Deleting managed server $deletingCacheServerNames failed"
+            exit 1
+    fi
+    echo "Complete deleting managed server $deletingCacheServerNames"
+}
+
+function delete_managed_machine()
 {
     . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
 
-    echo "Start to delete managed server machine $managedServerNames"
-    java $WLST_ARGS weblogic.WLST delete-machine.py
+    echo "Start to delete managed server machine $managedVMNames"
+    sudo chown -R ${username}:${groupname} ${wlsDomainsPath}
+    runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; java $WLST_ARGS weblogic.WLST ${wlsDomainsPath}/delete-machine.py"
     if [[ $? != 0 ]]; then
-            echo "Error : Deleting machine for managed server $managedServerNames failed"
+            echo "Error : Deleting machine $managedVMNames failed"
             exit 1
     fi
-    echo "Complete deleting managed server machine $managedServerNames"
+    echo "Complete deleting managed server machine $managedVMNames"
 }
 
 #main script starts here
+# store arguments in a special array
+args=("$@")
+# get number of elements
+ELEMENTS=${#args[@]}
 
-if [ $# -ne 7 ]
+# echo each element in array
+# for loop
+for ((i = 0; i < $ELEMENTS; i++)); do
+    echo "ARG[${args[${i}]}]"
+done
+
+if [ $# -ne 9 ]
 then
     usage
 	exit 1
@@ -154,9 +254,14 @@ export wlsForceShutDown=$4
 export wlsAdminHost=$5
 export wlsAdminPort=$6
 export oracleHome=$7
+export managedServerPrefix=$8
+export deletingCacheServerNames=$9
 export wlsAdminURL=$wlsAdminHost:$wlsAdminPort
 export hostName=`hostname`
 export wlsClusterName="cluster1"
+export username="oracle"
+export groupname="oracle"
+export wlsDomainsPath="/u01/domains"
 
 validateInput
 
@@ -164,8 +269,10 @@ cleanup
 
 wait_for_admin
 
+delete_cache_server
+
 delete_machine_model
 
-delete_managed_server_node
+delete_managed_machine
 
 cleanup

--- a/test/scripts/gen-parameters-coherence.sh
+++ b/test/scripts/gen-parameters-coherence.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+parametersPath=$1
+githubUserName=$2
+testbranchName=$3
+
+cat <<EOF >${parametersPath}
+{
+    "\$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "_artifactsLocation": {
+            "value": "https://raw.githubusercontent.com/${githubUserName}/arm-oraclelinux-wls-dynamic-cluster/${testbranchName}/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/"
+        },
+        "_artifactsLocationSasToken": {
+            "value": ""
+        },
+        "adminPasswordOrKey": {
+            "value": "GEN-UNIQUE"
+        },
+        "adminUsername": {
+            "value": "GEN-UNIQUE"
+        },
+        "adminVMName": {
+            "value": "GEN-UNIQUE"
+        },
+        "enableCoherence": {
+            "value": true
+        },
+        "wlsPassword": {
+            "value": "GEN-UNIQUE"
+        },
+        "wlsUserName": {
+            "value": "GEN-UNIQUE"
+        }
+    }
+}
+EOF

--- a/test/scripts/gen-parameters-deploy-addnode-coherence.sh
+++ b/test/scripts/gen-parameters-deploy-addnode-coherence.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#Generate parameters with value for deploying addnode template
+
+parametersPath=$1
+adminPasswordOrKey=$2
+adminVMName=$3
+adminUsername=$4
+numberOfExistingCacheNodes=$5
+skuUrnVersion=$6
+storageAccountName=${7}
+wlsDomainName=${8}
+location=${9}
+wlsusername=${10}
+wlspassword=${11}
+gitUserName=${12}
+testbranchName=${13}
+managedServerPrefix=${14}
+
+cat <<EOF > ${parametersPath}
+{
+     "adminPasswordOrKey":{
+        "value": "${adminPasswordOrKey}"
+      },
+      "adminVMName": {
+        "value": "${adminVMName}"
+      },
+      "adminUsername": {
+        "value": "${adminUsername}"
+      },
+      "numberOfExistingCacheNodes": {
+        "value": ${numberOfExistingCacheNodes}
+      },
+      "numberOfNewCacheNodes": {
+        "value": 1
+      },
+      "location": {
+        "value": "${location}"
+      },
+      "skuUrnVersion": {
+        "value": "${skuUrnVersion}"
+      },
+      "storageAccountName": {
+        "value": "${storageAccountName}"
+      },
+      "wlsDomainName": {
+        "value": "${wlsDomainName}"
+      },
+      "wlsPassword": {
+        "value": "${wlsPassword}"
+      },
+      "wlsUserName": {
+        "value": "${wlsUserName}"
+      },
+      "_artifactsLocation":{
+        "value": "https://raw.githubusercontent.com/${gitUserName}/arm-oraclelinux-wls-dynamic-cluster/${testbranchName}/addnode-coherence/src/main/"
+      },
+      "managedServerPrefix": {
+        "value": "${managedServerPrefix}"
+      }
+    }
+EOF

--- a/test/scripts/gen-parameters-deploy-coherence.sh
+++ b/test/scripts/gen-parameters-deploy-coherence.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#Generate parameters with value for deploying coherence template independently
+
+parametersPath=$1
+adminVMName=$2
+adminPasswordOrKey=$3
+skuUrnVersion=$4
+location=$5
+storageAccountName=$6
+wlsDomainName=$7
+wlsusername=$8
+wlspassword=$9
+gitUserName=${10}
+testbranchName=${11}
+managedServerPrefix=${12}
+
+cat <<EOF > ${parametersPath}
+{
+     "adminVMName":{
+        "value": "${adminVMName}"
+      },
+      "adminPasswordOrKey": {
+        "value": "${adminPasswordOrKey}"
+      },
+      "enableCoherenceWebLocalStorage": {
+        "value": true
+      },
+      "numberOfCoherenceCacheInstances": {
+        "value": 1
+      },
+      "skuUrnVersion": {
+        "value": "${skuUrnVersion}"
+      },
+      "location": {
+        "value": "${location}"
+      },
+      "storageAccountName": {
+        "value": "${storageAccountName}"
+      },
+      "wlsDomainName": {
+        "value": "${wlsDomainName}"
+      },
+      "wlsPassword": {
+        "value": "${wlsPassword}"
+      },
+      "wlsUserName": {
+        "value": "${wlsUserName}"
+      },
+      "_artifactsLocation":{
+        "value": "https://raw.githubusercontent.com/${gitUserName}/arm-oraclelinux-wls-dynamic-cluster/${testbranchName}/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/"
+      },
+      "managedServerPrefix": {
+        "value": "${managedServerPrefix}"
+      }
+    }
+EOF

--- a/test/scripts/gen-parameters-deploy-elk.sh
+++ b/test/scripts/gen-parameters-deploy-elk.sh
@@ -23,7 +23,7 @@ cat <<EOF > ${parametersPath}
         "value": "${adminVMName}"
       },
       "elasticsearchPassword": {
-        "value": "elasticsearchPassword"
+        "value": "${elasticsearchPassword}"
       },
       "elasticsearchEndpoint": {
         "value": "${elasticsearchURI}"
@@ -52,7 +52,7 @@ cat <<EOF > ${parametersPath}
       "maxDynamicClusterSize": {
         "value": ${maxDynamicClusterSize}
       },
-      "dynamicClusterSize": {
+      "numberOfManagedApplicationInstances": {
         "value": ${dynamicClusterSize}
       }
     }

--- a/test/scripts/verify-deployments.sh
+++ b/test/scripts/verify-deployments.sh
@@ -26,6 +26,10 @@ parametersList+=(${scriptsDir}/parameters-db.json)
 bash ${scriptsDir}/gen-parameters-aad.sh ${scriptsDir}/parameters-aad.json $githubUserName $testbranchName
 parametersList+=(${scriptsDir}/parameters-aad.json)
 
+# parameters for cluster+coherence
+bash ${scriptsDir}/gen-parameters-elk.sh ${scriptsDir}/parameters-coherence.json $githubUserName $testbranchName
+parametersList+=(${scriptsDir}/parameters-coherence.json)
+
 # parameters for cluster+elk
 bash ${scriptsDir}/gen-parameters-elk.sh ${scriptsDir}/parameters-elk.json $githubUserName $testbranchName
 parametersList+=(${scriptsDir}/parameters-elk.json)


### PR DESCRIPTION
This PR includes 7 commits, to create template for coherence set up, and add CI/CD steps for coherence template deployment.

### The structure of the coherence cluster
```
# managedServerPrefix: msp
|-- Coherence cluster: myCoherence
      |-- Application tier: cluster1
      |    |-- Server1: msp1
      |    |-- Server2: msp2
      |-- Data tier: storage1
           |-- Server1: mspStorage1
           |-- Server2: mspStorage2
```
### Settings of the cluster
`myCoherence`:
    Clustering Mode: Unicast
    Cluster Listen Port:7574
    Transport: UDP
    Time To Live:: 4
    Logging: Enabled
`cluster1`:
    Coherence Cluster: `myCoherence`
    Local Storage Enabled: `false`
    Coherence Web Local Storage Enabled: `false`
    Coherence Web Federated Storage Enabled: `false`
`storages1`:
    Coherence Cluster: myCoherence
    Local Storage Enabled: `yes`
    Coherence Web Local Storage Enabled: specify with parameters `enableCoherenceWebLocalStorage` in template, `yes` by default. 
    Coherence Web Federated Storage Enabled: `false`

### Network Communications
For images of Oracle Linux, firewall will block the communication between coherence cluster.
We open port 42000-42200 for coherence communication in virtual machine that hosting managed servers, including application nodes and cache nodes.
Specify the port range with server start arguments:
```
-Dcoherence.localport=42000 -Dcoherence.localport.adjust=42200
```

**Note**: Assuming the customers have requirements for coherence, in virtual machine that is provisioned with **Oracle Linux 7.6** image, which hosts **managed server**, we pre-open port `42000-42200`.