### PR TITLE
Adding OHS as load balancer for dynamic cluster

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -249,6 +249,256 @@
         ],
         "steps": [
             {
+                "name": "section_ohs",
+                "type": "Microsoft.Common.Section",
+                "label": "Oracle HTTP Server",
+                "elements": [
+                    {
+                        "name": "connectToOHSext",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "Selecting 'Yes' here will cause the template to provision an Azure Oracle HTTP Server setup a public IP, and configuration with WebLogic cluster address.  Further configuration may be necessary after deployment.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://docs.oracle.com/en/middleware/fusion-middleware/web-tier/12.2.1.4/index.html"
+                            }
+                        }
+                    },
+                    {
+                        "name": "enableOHS",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Connect to Oracle HTTP Server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to cause an Azure Oracle HTTP Server to be created as the load balancer for the cluster.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                },
+                                {
+                                    "label": "No",
+                                    "value": false
+                                }
+                            ],
+                            "required": false
+                        }
+                    },
+                    {
+                        "name": "keyVaultText",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": "[steps('section_ohs').enableOHS]",
+                        "options": {
+                            "text": "Oracle HTTP Server integration requires an SSL Certificate to enable SSL termination. End-to-end SSL encryption is not supported by the template.  The template will look for the certificate and its password in the Azure KeyVault specified here.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://aka.ms/arm-oraclelinux-wls-cluster-app-gateway-key-vault"
+                            }
+                        }
+                    },
+                    {
+                        "name": "ohsSkuUrnVersion",
+                        "type": "Microsoft.Common.DropDown",
+                        "label": "Oracle OHS Image",
+                        "defaultValue": "OHS Server 12.2.1.4.0 and JDK8 on Oracle Linux 7.6",
+                        "toolTip": "Choose Oracle OHS image, which is provided by Oracle, with Java and OHS preinstalled.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "OHS Server 12.2.1.4.0 and JDK8 on Oracle Linux 7.3",
+                                    "value": "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol73;latest"
+                                },
+                                {
+                                    "label": "OHS Server 12.2.1.4.0 and JDK8 on Oracle Linux 7.4",
+                                    "value": "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol74;latest"
+                                },
+                                {
+                                    "label": "OHS Server 12.2.1.4.0 and JDK8 on Oracle Linux 7.6",
+                                    "value": "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest"
+                                }
+                            ]
+                         },
+                         "visible": "[steps('section_ohs').enableOHS]"                    
+                    },
+                    {
+                        "name": "ohsDomainName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Oracle HTTP Server Domain name",
+                        "defaultValue": "",
+                        "toolTip": "Oracle HTTP Server Domain Name",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z.\\-_()]{0,89}([a-z0-9A-Z\\-_()]{1})$",
+                            "validationMessage": "[if(greater(length(steps('section_ohs').ohsDomainName), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "ohsComponentName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Oracle HTTP Server Component name",
+                        "defaultValue": "",
+                        "toolTip": "Oracle HTTP Server Component name",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z.\\-_()]{0,89}([a-z0-9A-Z\\-_()]{1})$",
+                            "validationMessage": "[if(greater(length(steps('section_ohs').ohsDomainName), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "ohsNMUser",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Oracle HTTP Server NodeManager username",
+                        "defaultValue": "",
+                        "toolTip": "Oracle HTTP Server NodeManager username",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z.\\-_()]{0,89}([a-z0-9A-Z\\-_()]{1})$",
+                            "validationMessage": "[if(greater(length(steps('section_ohs').ohsNMUser), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "ohsNMPassword",
+                        "type": "Microsoft.Common.PasswordBox",
+                        "label": {
+                            "password": "NodeManager Password",
+                            "confirmPassword": "Confirm password"
+                        },
+                        "toolTip": "Oracle HTTP Server NodeManager password",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-zA-Z0-9]{8,}$",
+                            "validationMessage": "Password must be at least 8 characters long, contain only numbers and letters"
+                        },
+                        "options": {
+                            "hideConfirmation": false
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "ohshttpPort",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Oracle HTTP Server HTTP Port",
+                        "defaultValue": "",
+                        "toolTip": "Oracle HTTP Server HTTP Port",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[0-9]+$",
+                            "validationMessage": "[if(greater(length(steps('section_ohs').ohshttpPort), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "ohshttpsPort",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Oracle HTTP Server HTTPS Port",
+                        "defaultValue": "",
+                        "toolTip": "Oracle HTTP Server HTTPS Port",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[0-9]+$",
+                            "validationMessage": "[if(greater(length(steps('section_ohs').ohshttpsPort), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "oracleVaultPswd",
+                        "type": "Microsoft.Common.PasswordBox",
+                        "label": {
+                            "password": "Oracle Vault Password",
+                            "confirmPassword": "Confirm password"
+                        },
+                        "toolTip": "Oracle Vault password",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-zA-Z0-9]{8,}$",
+                            "validationMessage": "Password must be at least 8 characters long, contain only numbers and letters"
+                        },
+                        "options": {
+                            "hideConfirmation": false
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "keyType",
+                        "type": "Microsoft.Common.DropDown",
+                        "label": "Certificate Type",
+                        "defaultValue": "PKCS12",
+                        "toolTip": "Type of the certificate format",
+                        "constraints": {
+                            "allowedValues": [
+                               {
+                                   "label": "PKCS12",
+                                   "value": "PKCS12"
+                               },
+                               {
+                                   "label": "JKS",
+                                   "value": "JKS"
+                               }
+                            ],
+                            "required": false
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "keyVaultResourceGroup",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Resource group name in current subscription containing the KeyVault",
+                        "defaultValue": "",
+                        "toolTip": "Use only letters and numbers",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z.\\-_()]{0,89}([a-z0-9A-Z\\-_()]{1})$",
+                            "validationMessage": "[if(greater(length(steps('section_ohs').keyVaultResourceGroup), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "keyVaultName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Name of the Azure KeyVault containing secrets for the Certificate for SSL Termination",
+                        "defaultValue": "",
+                        "toolTip": "Use only letters and numbers",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^(?=.{3,24}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)$",
+                            "validationMessage": "[if(or(greater(length(steps('section_ohs').keyVaultName), 24), less(length(steps('section_ohs').keyVaultName), 3)),'Vault name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens.','Vault name must only contain alphanumeric characters and dashes and cannot start with a number')]"
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "keyVaultSSLCertDataSecretName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "The name of the secret in the specified KeyVault whose value is the SSL Certificate Data",
+                        "defaultValue": "",
+                        "toolTip": "Use only letters and numbers",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z]{1,30}$",
+                            "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "keyVaultSSLCertPasswordSecretName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "The name of the secret in the specified KeyVault whose value is the password for the SSL Certificate",
+                        "defaultValue": "",
+                        "toolTip": "Use only letters and numbers",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z]{1,30}$",
+                            "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    }
+                ],
+                "visible": true
+            },		        
+            {
                 "name": "section_database",
                 "type": "Microsoft.Common.Section",
                 "label": "Database",
@@ -833,7 +1083,20 @@
             "wlsLDAPSSLCertificate": "[steps('section_aad').aadInfo.wlsLDAPSSLCertificate]",
             "wlsLDAPUserBaseDN": "[steps('section_aad').aadInfo.wlsLDAPUserBaseDN]",
             "wlsPassword": "[basics('basicsRequired').wlsPassword]",
-            "wlsUserName": "[basics('basicsRequired').wlsUserName]"
+            "wlsUserName": "[basics('basicsRequired').wlsUserName]",
+            "ohsSkuUrnVersion": "[steps('section_ohs').ohsSkuUrnVersion]",
+            "ohsDomainName": "[steps('section_ohs').ohsDomainName]",
+            "ohsComponentName": "[steps('section_ohs').ohsComponentName]",
+            "ohsNMUser": "[steps('section_ohs').ohsNMUser]",
+            "ohsNMPassword": "[steps('section_ohs').ohsNMPassword]",
+            "ohshttpPort": "[steps('section_ohs').ohshttpPort]",
+            "ohshttpsPort": "[steps('section_ohs').ohshttpsPort]",
+            "oracleVaultPswd": "[steps('section_ohs').oracleVaultPswd]",
+            "keyType": "[steps('section_ohs').keyType]",
+            "keyVaultResourceGroup": "[steps('section_ohs').keyVaultResourceGroup]",
+            "keyVaultName": "[steps('section_ohs').keyVaultName]",
+            "keyVaultSSLCertDataSecretName": "[steps('section_ohs').keyVaultSSLCertDataSecretName]",
+            "keyVaultSSLCertPasswordSecretName": "[steps('section_ohs').keyVaultSSLCertPasswordSecretName]"
         }
     }
 }

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -251,14 +251,14 @@
             {
                 "name": "section_ohs",
                 "type": "Microsoft.Common.Section",
-                "label": "Oracle HTTP Server",
+                "label": "Oracle HTTP Server Load Balancer",
                 "elements": [
                     {
                         "name": "connectToOHSext",
                         "type": "Microsoft.Common.TextBlock",
                         "visible": true,
                         "options": {
-                            "text": "Selecting 'Yes' here will cause the template to provision an Azure Oracle HTTP Server setup a public IP, and configuration with WebLogic cluster address.  Further configuration may be necessary after deployment.",
+                            "text": "Selecting 'Yes' here will cause the template to provision an Azure Oracle HTTP Server, setup a public IP, and configuration with WebLogic cluster address.  Further configuration may be necessary after deployment.",
                             "link": {
                                 "label": "Learn more",
                                 "uri": "https://docs.oracle.com/en/middleware/fusion-middleware/web-tier/12.2.1.4/index.html"
@@ -293,7 +293,7 @@
                             "text": "Oracle HTTP Server integration requires an SSL Certificate to enable SSL termination. End-to-end SSL encryption is not supported by the template.  The template will look for the certificate and its password in the Azure KeyVault specified here.",
                             "link": {
                                 "label": "Learn more",
-                                "uri": "https://aka.ms/arm-oraclelinux-wls-cluster-app-gateway-key-vault"
+                                "uri": "https://aka.ms/arm-oraclelinux-wls-dynamic-cluster-ohs"
                             }
                         }
                     },

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
@@ -152,11 +152,57 @@
                 "description": "If true, use the supplied parameters to distribute WebLogic Server logs to the Elasticsearch instance."
             }
         },
-        "jdbcDataSourceName": {
+         "enableOHS": {
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "Bool value, if it's set to true, it will setup OHS and configures for WebLogic Server cluster"            
+            }        
+        },
+       "jdbcDataSourceName": {
             "defaultValue": "",
             "type": "string",
             "metadata": {
                 "description": "JNDI Name for JDBC Datasource"
+            }
+        },
+        "keyType": {
+            "type": "string",
+            "defaultValue": "PKCS12",
+            "allowedValues": [
+              "JKS",
+              "PKCS12"            
+            ],
+            "metadata": {
+                "description": "Provide Key type is JKS or PKCS12 signed certificates for OHS. Default is PKCS12 format"            
+            }
+        },
+        "keyVaultName": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "KeyVault Name where certificates are stored for OHS" 
+            }
+        },
+        "keyVaultResourceGroup": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "Resource group name in current subscription containing the KeyVault for OHS" 
+            }
+        },
+        "keyVaultSSLCertDataSecretName": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the SSL Certificate Data for OHS" 
+            }
+        },
+        "keyVaultSSLCertPasswordSecretName": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the password for the SSL Certificate for OHS" 
             }
         },
         "location": {
@@ -197,6 +243,74 @@
                 "description": "Number of Coherence cache instances, used to create virtual machines and Managed Server."
             }
         },
+        "ohsComponentName": {
+            "defaultValue": "ohs_azure",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS component name"          
+            }
+        },
+        "ohsDomainName": {
+            "defaultValue": "ohsStandaloneDomain",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS domain name"            
+            }
+        },
+        "ohsNMPassword": {
+            "defaultValue": "",
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for OHS NodeManager"      
+            }
+        },
+        "ohsNMUser": {
+            "defaultValue": "weblogic",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS NodeManager user name"       
+            }
+        },
+        "ohsSkuUrnVersion": {
+            "type": "string",
+            "defaultValue": "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
+            "allowedValues": [
+              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
+              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol74;latest",
+              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol73;latest"
+             ],                    
+            "metadata": {
+                "description": "The Oracle Linux image with OHS and Java preinstalled. Semicolon separated string of Sku, URN, and Version"            
+            }
+        },
+        "ohsVMName": {
+            "defaultValue": "ohsVM",
+            "type": "string",
+            "metadata": {
+                "description": "OHS Server hosting VM name."
+            }
+        },
+        "ohshttpPort": {
+            "defaultValue": "7777",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS HTTP port"  
+            }
+        },
+        "ohshttpsPort": {
+            "defaultValue": "4444",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS HTTPS port"  
+            }
+        },
+        "oracleVaultPswd": {
+            "defaultValue": "",
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for Oracle Vault required for OHS"      
+            }
+        },      
         "portsToExpose": {
             "defaultValue": "80,443,7001-9000",
             "type": "string",
@@ -300,121 +414,7 @@
             "metadata": {
                 "description": "Username for your Weblogic domain name"
             }
-        },
-        "enableOHS": {
-            "defaultValue": false,
-            "type": "bool",
-            "metadata": {
-                "description": "Bool value, if it's set to true, it will setup OHS and configures for WebLogic Server cluster"            
-            }        
-        },
-        "ohsSkuUrnVersion": {
-            "type": "string",
-            "defaultValue": "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
-            "allowedValues": [
-              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
-              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol74;latest",
-              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol73;latest"
-             ],                    
-            "metadata": {
-                "description": "The Oracle Linux image with OHS and Java preinstalled. Semicolon separated string of Sku, URN, and Version"            
-            }
-        },
-        "ohsVMName": {
-            "defaultValue": "ohsVM",
-            "type": "string",
-            "metadata": {
-                "description": "OHS Server hosting VM name."
-            }
-        },
-        "ohsDomainName": {
-            "defaultValue": "ohsStandaloneDomain",
-            "type": "string",
-            "metadata": {
-                "description": "Provide OHS domain name"            
-            }
-        },
-        "ohsComponentName": {
-            "defaultValue": "ohs_azure",
-            "type": "string",
-            "metadata": {
-                "description": "Provide OHS component name"          
-            }
-        },
-        "ohsNMUser": {
-            "defaultValue": "weblogic",
-            "type": "string",
-            "metadata": {
-                "description": "Provide OHS NodeManager user name"       
-            }
-        },
-        "ohsNMPassword": {
-            "defaultValue": "",
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for OHS NodeManager"      
-            }
-        },
-        "ohshttpPort": {
-            "defaultValue": "7777",
-            "type": "string",
-            "metadata": {
-                "description": "Provide OHS HTTP port"  
-            }
-        },
-        "ohshttpsPort": {
-            "defaultValue": "4444",
-            "type": "string",
-            "metadata": {
-                "description": "Provide OHS HTTPS port"  
-            }
-        },
-        "keyType":{
-            "type": "string",
-            "defaultValue": "PKCS12",
-            "allowedValues": [
-              "JKS",
-              "PKCS12"            
-            ],
-            "metadata": {
-                "description": "Provide Key type is JKS or PKCS12 signed certificates for OHS. Default is PKCS12 format"            
-            }
-        },
-        "keyVaultName": {
-            "defaultValue": "",
-            "type": "string",
-            "metadata": {
-                "description": "KeyVault Name where certificates are stored for OHS" 
-            }
-        },
-        "keyVaultResourceGroup": {
-            "defaultValue": "",
-            "type": "string",
-            "metadata": {
-                "description": "Resource group name in current subscription containing the KeyVault for OHS" 
-            }
-        },
-        "keyVaultSSLCertDataSecretName": {
-            "defaultValue": "",
-            "type": "string",
-            "metadata": {
-                "description": "The name of the secret in the specified KeyVault whose value is the SSL Certificate Data for OHS" 
-            }
-        },
-        "keyVaultSSLCertPasswordSecretName": {
-            "defaultValue": "",
-            "type": "string",
-            "metadata": {
-                "description": "The name of the secret in the specified KeyVault whose value is the password for the SSL Certificate for OHS" 
-            }
-        },
-        "oracleVaultPswd": {
-            "defaultValue": "",
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for Oracle Vault required for OHS"      
-            }
-        }      
+        }
     },
     "variables": {
         "const_currentSubscription": "[subscription().subscriptionId]",
@@ -805,30 +805,6 @@
                     "adminPasswordOrKey": {
                         "value": "[parameters('adminPasswordOrKey')]"                    
                     },
-                    "ohsSkuUrnVersion": {
-                        "value": "[parameters('ohsSkuUrnVersion')]"                    
-                    },
-                    "ohsVMName": {
-                        "value": "[parameters('ohsVMName')]"                    
-                    },
-                    "ohsDomainName": {
-                        "value": "[parameters('ohsDomainName')]"                    
-                    },
-                    "ohsComponentName": {
-                        "value": "[parameters('ohsComponentName')]"                    
-                    },
-                    "ohsNMUser": {
-                        "value": "[parameters('ohsNMUser')]"                    
-                    },
-                    "ohsNMPassword": {
-                        "value": "[parameters('ohsNMPassword')]"                    
-                    },
-                    "ohshttpPort": {
-                        "value": "[parameters('ohshttpPort')]"                    
-                    },
-                    "ohshttpsPort": {
-                        "value": "[parameters('ohshttpsPort')]"                    
-                    },
                     "dnsLabelPrefix": {
                         "value": "[parameters('dnsLabelPrefix')]"
                     },
@@ -838,23 +814,29 @@
                     "location": {
                         "value": "[parameters('location')]"
                     },
-                    "virtualNetworkName": {
-                        "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.virtualNetworkName.value]"					
+                    "ohsComponentName": {
+                        "value": "[parameters('ohsComponentName')]"                    
                     },
-                    "oracleVaultPswd": {
-                        "value": "[parameters('oracleVaultPswd')]"					
+                    "ohsDomainName": {
+                        "value": "[parameters('ohsDomainName')]"                    
                     },
-                    "adminRestMgmtURL": {
-                        "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminRestMgmtURL.value]"					
+                    "ohsNMPassword": {
+                        "value": "[parameters('ohsNMPassword')]"                    
                     },
-                    "wlsPassword": {
-                        "value": "[parameters('wlsPassword')]"					
+                    "ohsNMUser": {
+                        "value": "[parameters('ohsNMUser')]"                    
                     },
-                    "wlsUserName": {
-                        "value": "[parameters('wlsUserName')]"					
+                    "ohsSkuUrnVersion": {
+                        "value": "[parameters('ohsSkuUrnVersion')]"                    
                     },
-                    "keyType": {
-                        "value": "[parameters('keyType')]"					
+                    "ohsVMName": {
+                        "value": "[parameters('ohsVMName')]"                    
+                    },
+                    "ohshttpPort": {
+                        "value": "[parameters('ohshttpPort')]"                    
+                    },
+                    "ohshttpsPort": {
+                        "value": "[parameters('ohshttpsPort')]"                    
                     },
                     "ohsSSLKeystoreData": {
                         "reference": {
@@ -871,9 +853,27 @@
                             },
                             "secretName": "[parameters('keyVaultSSLCertPasswordSecretName')]"
                         }					
+                    },
+                    "oracleVaultPswd": {
+                        "value": "[parameters('oracleVaultPswd')]"					
+                    },
+                    "virtualNetworkName": {
+                        "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.virtualNetworkName.value]"					
+                    },
+                    "adminRestMgmtURL": {
+                        "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminRestMgmtURL.value]"					
+                    },
+                    "wlsPassword": {
+                        "value": "[parameters('wlsPassword')]"					
+                    },
+                    "wlsUserName": {
+                        "value": "[parameters('wlsUserName')]"					
+                    },
+                    "keyType": {
+                        "value": "[parameters('keyType')]"					
                     }
                 }
-            }		                        					
+            }
         },
         {
             "type": "Microsoft.Resources/deployments",

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
@@ -300,14 +300,130 @@
             "metadata": {
                 "description": "Username for your Weblogic domain name"
             }
-        }
+        },
+        "enableOHS": {
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "Bool value, if it's set to true, it will setup OHS and configures for WebLogic Server cluster"            
+            }        
+        },
+        "ohsSkuUrnVersion": {
+            "type": "string",
+            "defaultValue": "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
+            "allowedValues": [
+              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
+              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol74;latest",
+              "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol73;latest"
+             ],                    
+            "metadata": {
+                "description": "The Oracle Linux image with OHS and Java preinstalled. Semicolon separated string of Sku, URN, and Version"            
+            }
+        },
+        "ohsVMName": {
+            "defaultValue": "ohsVM",
+            "type": "string",
+            "metadata": {
+                "description": "OHS Server hosting VM name."
+            }
+        },
+        "ohsDomainName": {
+            "defaultValue": "ohsStandaloneDomain",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS domain name"            
+            }
+        },
+        "ohsComponentName": {
+            "defaultValue": "ohs_azure",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS component name"          
+            }
+        },
+        "ohsNMUser": {
+            "defaultValue": "weblogic",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS NodeManager user name"       
+            }
+        },
+        "ohsNMPassword": {
+            "defaultValue": "",
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for OHS NodeManager"      
+            }
+        },
+        "ohshttpPort": {
+            "defaultValue": "7777",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS HTTP port"  
+            }
+        },
+        "ohshttpsPort": {
+            "defaultValue": "4444",
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS HTTPS port"  
+            }
+        },
+        "keyType":{
+            "type": "string",
+            "defaultValue": "PKCS12",
+            "allowedValues": [
+              "JKS",
+              "PKCS12"            
+            ],
+            "metadata": {
+                "description": "Provide Key type is JKS or PKCS12 signed certificates for OHS. Default is PKCS12 format"            
+            }
+        },
+        "keyVaultName": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "KeyVault Name where certificates are stored for OHS" 
+            }
+        },
+        "keyVaultResourceGroup": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "Resource group name in current subscription containing the KeyVault for OHS" 
+            }
+        },
+        "keyVaultSSLCertDataSecretName": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the SSL Certificate Data for OHS" 
+            }
+        },
+        "keyVaultSSLCertPasswordSecretName": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the password for the SSL Certificate for OHS" 
+            }
+        },
+        "oracleVaultPswd": {
+            "defaultValue": "",
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for Oracle Vault required for OHS"      
+            }
+        }      
     },
     "variables": {
+        "const_currentSubscription": "[subscription().subscriptionId]",
         "name_aadLinkedTemplateName": "aadNestedTemplate.json",
         "name_clusterLinkedTemplateName": "clusterTemplate.json",
         "name_dbLinkedTemplateName": "dbTemplate.json",
         "name_elkLinkedTemplateName": "elkNestedTemplate.json",
-        "name_coherenceTemplateName": "coherenceTemplate.json"
+        "name_coherenceTemplateName": "coherenceTemplate.json",
+        "name_ohsLinkedTemplateName": "ohsNestedTemplate.json"
     },
     "resources": [
         {
@@ -663,6 +779,103 @@
             }
         },
         {
+            "name": "ohsLinkedTemplate",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'clusterLinkedTemplate')]"
+            ],
+            "apiVersion": "${azure.apiVersion}",
+            "condition": "[parameters('enableOHS')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/', variables('name_ohsLinkedTemplateName')))]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "_artifactsLocation": {
+                        "value": "[parameters('_artifactsLocation')]"
+                    },
+                    "_artifactsLocationSasToken": {
+                        "value": "[parameters('_artifactsLocationSasToken')]"
+                    },
+                    "adminUsername": {
+                        "value": "[parameters('adminUsername')]"                  
+                    },
+                    "adminPasswordOrKey": {
+                        "value": "[parameters('adminPasswordOrKey')]"                    
+                    },
+                    "ohsSkuUrnVersion": {
+                        "value": "[parameters('ohsSkuUrnVersion')]"                    
+                    },
+                    "ohsVMName": {
+                        "value": "[parameters('ohsVMName')]"                    
+                    },
+                    "ohsDomainName": {
+                        "value": "[parameters('ohsDomainName')]"                    
+                    },
+                    "ohsComponentName": {
+                        "value": "[parameters('ohsComponentName')]"                    
+                    },
+                    "ohsNMUser": {
+                        "value": "[parameters('ohsNMUser')]"                    
+                    },
+                    "ohsNMPassword": {
+                        "value": "[parameters('ohsNMPassword')]"                    
+                    },
+                    "ohshttpPort": {
+                        "value": "[parameters('ohshttpPort')]"                    
+                    },
+                    "ohshttpsPort": {
+                        "value": "[parameters('ohshttpsPort')]"                    
+                    },
+                    "dnsLabelPrefix": {
+                        "value": "[parameters('dnsLabelPrefix')]"
+                    },
+                    "storageAccountName": {
+                        "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.storageAccountName.value]"					
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.virtualNetworkName.value]"					
+                    },
+                    "oracleVaultPswd": {
+                        "value": "[parameters('oracleVaultPswd')]"					
+                    },
+                    "adminRestMgmtURL": {
+                        "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminRestMgmtURL.value]"					
+                    },
+                    "wlsPassword": {
+                        "value": "[parameters('wlsPassword')]"					
+                    },
+                    "wlsUserName": {
+                        "value": "[parameters('wlsUserName')]"					
+                    },
+                    "keyType": {
+                        "value": "[parameters('keyType')]"					
+                    },
+                    "ohsSSLKeystoreData": {
+                        "reference": {
+                            "keyVault": {
+                                "id": "[resourceId(variables('const_currentSubscription'),  parameters('keyVaultResourceGroup'), 'Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
+                            },
+                            "secretName": "[parameters('keyVaultSSLCertDataSecretName')]"
+                        }                                                    
+                    },
+                    "ohsSSLKeystorePassword": {
+                        "reference": {
+                            "keyVault": {
+                                "id": "[resourceId(variables('const_currentSubscription'),  parameters('keyVaultResourceGroup'), 'Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
+                            },
+                            "secretName": "[parameters('keyVaultSSLCertPasswordSecretName')]"
+                        }					
+                    }
+                }
+            }		                        					
+        },
+        {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
             "name": "${dynamic.end}",
@@ -671,7 +884,8 @@
                 "[resourceId('Microsoft.Resources/deployments', 'aadLinkedTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'dbLinkedTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'elkLinkedTemplate')]",
-                "[resourceId('Microsoft.Resources/deployments', 'coherenceTemplate')]"
+                "[resourceId('Microsoft.Resources/deployments', 'coherenceTemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'ohsLinkedTemplate')]"
             ],
             "properties": {
                 "mode": "Incremental",

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -585,6 +585,14 @@
         "storageAccountName": {
             "type": "string",
             "value": "[variables('name_storageAccount')]"
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "value": "[variables('name_virtualNetwork')]"
+        },
+        "adminRestMgmtURL":{
+            "type": "string",
+            "value": "[concat('http://',parameters('adminVMName'),':7001/management/weblogic/latest')]"
         }
     }
 }

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/ohsNestedTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/ohsNestedTemplate.json
@@ -22,10 +22,16 @@
                 "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured."
             }
         },
-        "ohsVMName": {
+        "adminPasswordOrKey": {
+            "type": "securestring",
+            "metadata": {
+                "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+            }
+        },
+        "adminRestMgmtURL": {
             "type": "string",
             "metadata": {
-                "description": "User name for the Virtual Machine."
+                "description": "Provide admin REST management URL"
             }
         },
         "adminUsername": {
@@ -45,10 +51,67 @@
                 "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
             }
         },
-        "adminPasswordOrKey": {
+        "dnsLabelPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "guidValue": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "keyType": {
+            "type": "string",
+            "defaultValue": "PKCS12",
+            "allowedValues": [
+                "JKS",
+                "PKCS12"
+            ],
+            "metadata": {
+                "description": "Provide Key type is JKS or PKCS12 signed certificates"
+            }
+        },
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "ohsComponentName": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS component name"
+            }
+        },
+        "ohsDomainName": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS domain name"
+            }
+        },
+        "ohsNMPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+                "description": "Password for OHS NodeManager"
+            }
+        },
+        "ohsNMUser": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS NodeManager user name"
+            }
+        },
+        "ohsSSLKeystoreData": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the SSL Certificate Data"
+            }
+        },
+        "ohsSSLKeystorePassword": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the password for the SSL Certificate"
             }
         },
         "ohsSkuUrnVersion": {
@@ -63,32 +126,10 @@
                 "description": "The Oracle Linux image with OHS and Java preinstalled. Semicolon separated string of Sku, URN, and Version"
             }
         },
-        "guidValue": {
-            "type": "string",
-            "defaultValue": "[newGuid()]"
-        },
-        "ohsDomainName": {
+        "ohsVMName": {
             "type": "string",
             "metadata": {
-                "description": "Provide OHS domain name"
-            }
-        },
-        "ohsComponentName": {
-            "type": "string",
-            "metadata": {
-                "description": "Provide OHS component name"
-            }
-        },
-        "ohsNMUser": {
-            "type": "string",
-            "metadata": {
-                "description": "Provide OHS NodeManager user name"
-            }
-        },
-        "ohsNMPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for OHS NodeManager"
+                "description": "User name for the Virtual Machine."
             }
         },
         "ohshttpPort": {
@@ -103,22 +144,16 @@
                 "description": "Provide OHS HTTPS port"
             }
         },
-        "dnsLabelPrefix": {
+        "oracleVaultPswd": {
             "type": "string",
             "metadata": {
-                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+				"description": "Password for Oracle Vault required for OHS SSL setup"
             }
         },
         "storageAccountName": {
             "type": "string",
             "metadata": {
                 "description": "Name of storage account. One storage account can store 20 vitual machines with 2 VHDs of 500 IOPS."
-            }
-        },
-        "location": {
-            "type": "string",
-            "metadata": {
-                "description": "Location for all resources."
             }
         },
         "virtualNetworkName": {
@@ -134,12 +169,6 @@
                 "description": "Select appropriate VM Size as per requirement"
             }
         },
-        "adminRestMgmtURL": {
-            "type": "string",
-            "metadata": {
-                "description": "Provide admin REST management URL"
-            }
-        },
         "wlsPassword": {
             "type": "string",
             "metadata": {
@@ -151,50 +180,11 @@
             "metadata": {
                 "description": "Provide WebLogic username"
             }
-        },
-        "keyType": {
-            "type": "string",
-            "defaultValue": "PKCS12",
-            "allowedValues": [
-                "JKS",
-                "PKCS12"
-            ],
-            "metadata": {
-                "description": "Provide Key type is JKS or PKCS12 signed certificates"
-            }
-        },
-        "ohsSSLKeystoreData": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the secret in the specified KeyVault whose value is the SSL Certificate Data"
-            }
-        },
-        "ohsSSLKeystorePassword": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the secret in the specified KeyVault whose value is the password for the SSL Certificate"
-            }
-        },
-        "oracleVaultPswd": {
-            "type": "string",
-            "metadata": {
-				"description": "Password for Oracle Vault required for OHS SSL setup"
-            }
         }
     },
     "variables": {
-        "const_imagePublisher": "oracle",
-        "name_ohsSkuUrnVersion": "[split(parameters('ohsSkuUrnVersion'), ';')]",
         "const_imageOffer": "[variables('name_ohsSkuUrnVersion')[0]]",
-        "name_linuxImageOfferSKU": "[variables('name_ohsSkuUrnVersion')[1]]",
-        "name_linuxImageVersion": "[variables('name_ohsSkuUrnVersion')[2]]",
-        "name_nic": "_NIC",
-        "name_subnet": "Subnet",
-        "name_publicIPAddress": "_PublicIP",
-        "const_publicIPAddressType": "Dynamic",
-        "const_vmSize": "[parameters('vmSizeSelect')]",
-        "name_scriptFile": "setupOHS.sh",
-        "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
+        "const_imagePublisher": "oracle",
         "const_linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {
@@ -206,7 +196,17 @@
                 ]
             }
         },
+        "const_publicIPAddressType": "Dynamic",
+        "const_vmSize": "[parameters('vmSizeSelect')]",
+        "name_linuxImageOfferSKU": "[variables('name_ohsSkuUrnVersion')[1]]",
+        "name_linuxImageVersion": "[variables('name_ohsSkuUrnVersion')[2]]",
+        "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
+        "name_nic": "_NIC",
+        "name_ohsSkuUrnVersion": "[split(parameters('ohsSkuUrnVersion'), ';')]",
         "name_outputOHSHost": "[concat(parameters('ohsVMName'),variables('name_publicIPAddress'))]",
+        "name_publicIPAddress": "_PublicIP",
+        "name_scriptFile": "setupOHS.sh",
+        "name_subnet": "Subnet",
         "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('name_subnet'))]"
     },
     "resources": [

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/ohsNestedTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/ohsNestedTemplate.json
@@ -1,0 +1,374 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "_artifactsLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+            }
+        },
+        "_artifactsLocationOHSTemplate": {
+            "defaultValue": "[if(contains(parameters('_artifactsLocation'), 'githubusercontent'), parameters('_artifactsLocation'), deployment().properties.templateLink.uri)]",
+            "type": "string",
+            "metadata": {
+                "description": "If we are deploying from the command line, use the passed in _artifactsLocation, otherwise use the default."
+            }
+        },
+        "_artifactsLocationSasToken": {
+            "defaultValue": "",
+            "type": "securestring",
+            "metadata": {
+                "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured."
+            }
+        },
+        "ohsVMName": {
+            "type": "string",
+            "metadata": {
+                "description": "User name for the Virtual Machine."
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "User name for the Virtual Machine."
+            }
+        },
+        "authenticationType": {
+            "type": "string",
+            "defaultValue": "password",
+            "allowedValues": [
+                "sshPublicKey",
+                "password"
+            ],
+            "metadata": {
+                "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+            }
+        },
+        "adminPasswordOrKey": {
+            "type": "securestring",
+            "metadata": {
+                "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+            }
+        },
+        "ohsSkuUrnVersion": {
+            "type": "string",
+            "defaultValue": "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
+            "allowedValues": [
+                "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol76;latest",
+                "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol74;latest",
+                "wls-base-image-test1-preview;test-ohs-122140-jdk8-ol73;latest"
+            ],
+            "metadata": {
+                "description": "The Oracle Linux image with OHS and Java preinstalled. Semicolon separated string of Sku, URN, and Version"
+            }
+        },
+        "guidValue": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "ohsDomainName": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS domain name"
+            }
+        },
+        "ohsComponentName": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS component name"
+            }
+        },
+        "ohsNMUser": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS NodeManager user name"
+            }
+        },
+        "ohsNMPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Password for OHS NodeManager"
+            }
+        },
+        "ohshttpPort": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS HTTP port"
+            }
+        },
+        "ohshttpsPort": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide OHS HTTPS port"
+            }
+        },
+        "dnsLabelPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "storageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of storage account. One storage account can store 20 vitual machines with 2 VHDs of 500 IOPS."
+            }
+        },
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "metadata": {
+                "description": "virtual network name."
+            }
+        },
+        "vmSizeSelect": {
+            "type": "string",
+            "defaultValue": "Standard_A3",
+            "metadata": {
+                "description": "Select appropriate VM Size as per requirement"
+            }
+        },
+        "adminRestMgmtURL": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide admin REST management URL"
+            }
+        },
+        "wlsPassword": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide WebLogic password"
+            }
+        },
+        "wlsUserName": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide WebLogic username"
+            }
+        },
+        "keyType": {
+            "type": "string",
+            "defaultValue": "PKCS12",
+            "allowedValues": [
+                "JKS",
+                "PKCS12"
+            ],
+            "metadata": {
+                "description": "Provide Key type is JKS or PKCS12 signed certificates"
+            }
+        },
+        "ohsSSLKeystoreData": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the SSL Certificate Data"
+            }
+        },
+        "ohsSSLKeystorePassword": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the secret in the specified KeyVault whose value is the password for the SSL Certificate"
+            }
+        },
+        "oracleVaultPswd": {
+            "type": "string",
+            "metadata": {
+				"description": "Password for Oracle Vault required for OHS SSL setup"
+            }
+        }
+    },
+    "variables": {
+        "const_imagePublisher": "oracle",
+        "name_ohsSkuUrnVersion": "[split(parameters('ohsSkuUrnVersion'), ';')]",
+        "const_imageOffer": "[variables('name_ohsSkuUrnVersion')[0]]",
+        "name_linuxImageOfferSKU": "[variables('name_ohsSkuUrnVersion')[1]]",
+        "name_linuxImageVersion": "[variables('name_ohsSkuUrnVersion')[2]]",
+        "name_nic": "_NIC",
+        "name_subnet": "Subnet",
+        "name_publicIPAddress": "_PublicIP",
+        "const_publicIPAddressType": "Dynamic",
+        "const_vmSize": "[parameters('vmSizeSelect')]",
+        "name_scriptFile": "setupOHS.sh",
+        "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
+        "const_linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                        "keyData": "[parameters('adminPasswordOrKey')]"
+                    }
+                ]
+            }
+        },
+        "name_outputOHSHost": "[concat(parameters('ohsVMName'),variables('name_publicIPAddress'))]",
+        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('name_subnet'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+            "name": "[concat( variables('name_networkSecurityGroup'),'/','OHSPorts')]",
+            "apiVersion": "${azure.apiVersion}",
+            "properties": {
+                "protocol": "TCP",
+                "sourcePortRange": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 300,
+                "direction": "Inbound",
+                "destinationPortRanges": "[split(concat(parameters('ohshttpPort'),',',parameters('ohshttpsPort')), ',')]",
+                "sourceAddressPrefix": "*"
+            }
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(parameters('ohsVMName'),variables('name_publicIPAddress'))]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('const_publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[concat(toLower(parameters('dnsLabelPrefix')),'-',take(replace(parameters('guidValue'), '-', ''), 10),'-',toLower(parameters('ohsDomainName')))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(parameters('virtualNetworkName'), '/', variables('name_subnet'))]",
+            "condition": "[and(empty(parameters('virtualNetworkName')), empty(variables('name_subnet')))]"
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(parameters('ohsVMName'), variables('name_nic'))]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('ohsVMName'),variables('name_publicIPAddress')))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('ohsVMName'),variables('name_publicIPAddress')))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ],
+                "dnsSettings": {
+                    "internalDnsNameLabel": "[parameters('ohsVMName')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[parameters('ohsVMName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces/', concat(parameters('ohsVMName'), variables('name_nic')))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('const_vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[parameters('ohsVMName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPasswordOrKey')]",
+                    "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('const_imagePublisher')]",
+                        "offer": "[variables('const_imageOffer')]",
+                        "sku": "[variables('name_linuxImageOfferSKU')]",
+                        "version": "[variables('name_linuxImageVersion')]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "StandardSSD_LRS"
+                        }
+                    },
+                    "dataDisks": [
+                        {
+                            "lun": 0,
+                            "createOption": "FromImage",
+                            "diskSizeGB": 900,
+                            "managedDisk": {
+                                "storageAccountType": "StandardSSD_LRS"
+                            }
+                        }
+                    ]
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('ohsVMName'), variables('name_nic')))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true,
+                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), '${azure.apiVersion2}').primaryEndpoints.blob]"
+                    }
+                }
+            },
+            "plan": {
+                "name": "[variables('name_linuxImageOfferSKU')]",
+                "publisher": "[variables('const_imagePublisher')]",
+                "product": "[variables('const_imageOffer')]"
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('ohsVMName'),'/newuserscript')]",
+            "apiVersion": "${azure.apiVersion}",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+				"[resourceId('Microsoft.Compute/virtualMachines/', parameters('ohsVMName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "fileUris": [
+                        "[uri(parameters('_artifactsLocationOHSTemplate'), concat('../scripts/', variables('name_scriptFile'), parameters('_artifactsLocationSasToken')))]"
+                    ]
+                },
+                "protectedSettings": {
+                    "commandToExecute": "[concat('sh setupOHS.sh',' ',parameters('ohsDomainName'),' ',parameters('ohsComponentName'),' ',parameters('ohsNMUser'),' ',parameters('ohsNMPassword'),' ',parameters('ohshttpPort'),' ',parameters('ohshttpsPort'),' ',parameters('adminRestMgmtURL'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',base64(parameters('ohsSSLKeystoreData')),' ',base64(parameters('ohsSSLKeystorePassword')),' ',parameters('oracleVaultPswd'),' ',parameters('keyType'))]"
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "ohsHostName": {
+            "type": "string",
+            "value": "[reference(variables('name_outputOHSHost'), '${azure.apiVersion}').dnsSettings.fqdn]"
+        },
+        "ohsAccessURL": {
+            "type": "string",
+            "value": "[concat('http://',reference(variables('name_outputOHSHost'), '${azure.apiVersion}').dnsSettings.fqdn,':',parameters('ohshttpPort'))]"
+        },
+        "ohsSecureAccessURL": {
+            "type": "string",
+            "value": "[concat('https://',reference(variables('name_outputOHSHost'), '${azure.apiVersion}').dnsSettings.fqdn,':',parameters('ohshttpsPort'))]"
+        }
+    }
+}

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupDynamicClusterDomain.sh
@@ -518,7 +518,7 @@ function updateNetworkRules()
         maxManagedIndex=1
         echo "update network rules for managed server"
         # Port is dynamic betweent 8002 to 8001+dynamicClusterSize, open port from 8002 to 8001+dynamicClusterSize for managed machines.
-        while [ $maxManagedIndex -le $dynamicClusterSize ]
+        while [ $maxManagedIndex -le $maxDynamicClusterSize ]
         do
           managedPort=$(($wlsManagedPort + $maxManagedIndex))
           sudo firewall-cmd --zone=public --add-port=$managedPort/tcp

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupOHS.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupOHS.sh
@@ -1,0 +1,514 @@
+#!/bin/bash
+
+#Function to output message to StdErr
+function echo_stderr ()
+{
+    echo "$@" >&2
+}
+
+#Function to display usage message
+function usage()
+{
+    echo_stderr "./setupOHS.sh <ohs domain name> <ohs component name> <ohs nodemanager user> <ohs nodemanager password> <ohs http port> <ohs https port> <adminRestMgmtURL> <wlsUsername> <wlsPassword> <ohsSSLKeystoreData> <ohsSSLKeystorePassword> <oracle vault password> <keyType>"
+}
+
+# Create user "oracle", used for instalation and setup
+function addOracleGroupAndUser()
+{
+    #add oracle group and user
+    echo "Adding oracle user and group..."
+    groupname="oracle"
+    username="oracle"
+    user_home_dir="/u01/oracle"
+    USER_GROUP=${groupname}
+    sudo groupadd $groupname
+    sudo useradd -d ${user_home_dir} -g $groupname $username
+}
+
+# Cleaning all installer files 
+function cleanup()
+{
+    echo "Cleaning up temporary files..."
+    rm -f $BASE_DIR/setupOHS.sh
+    rm -f $OHS_PATH/ohs-domain.py
+    echo "Cleanup completed."
+}
+
+# Verifies whether user inputs are available
+function validateInput()
+{
+    if [ -z "$OHS_DOMAIN_NAME" ]
+    then
+       echo_stderr "OHS domain name is required. "
+       exit 1
+    fi	
+    
+    if [ -z "$OHS_COMPONENT_NAME" ]
+    then
+       echo_stderr "OHS domain name is required. "
+       exit 1
+    fi	
+    
+    if [[ -z "$OHS_NM_USER" || -z "$OHS_NM_PSWD" ]]
+    then
+       echo_stderr "OHS nodemanager username and password is required. "
+       exit 1
+    fi	
+    
+    if [[ -z "$OHS_HTTP_PORT" || -z "$OHS_HTTPS_PORT" ]]
+    then
+       echo_stderr "OHS http port and OHS https port required."
+       exit 1
+    fi	
+    
+    if [ -z "$WLS_REST_URL" ] 
+    then
+       echo_stderr "WebLogic REST management url is required."
+       exit 1
+    fi
+    
+    if [ -z "${OHS_KEY_STORE_DATA}" ] || [ -z "${OHS_KEY_STORE_PASSPHRASE}" ]
+    then
+       echo_stderr "One of the required values for enabling Custom SSL (ohsKeyStoreData,ohsKeyStorePassPhrase) is not provided"
+    fi
+    
+    if [ -z "$ORACLE_VAULT_PASSWORD" ]
+    then
+       echo_stderr "Oracle vault password is required to add custom ssl to OHS server"
+    fi
+    
+    if [ -z "${WLS_USER}" ] || [ -z "${WLS_PASSWORD}" ]
+    then
+       echo_stderr "Either weblogic username or weblogic password is required"
+    fi
+    
+    if [ -z "$OHS_KEY_TYPE" ] 
+    then
+       echo_stderr "Provide KeyType either JKS or PKCS12"
+    fi    
+}
+
+# Setup Domain path
+function setupDomainPath()
+{
+    #create custom directory for setting up wls and jdk
+    sudo mkdir -p $DOMAIN_PATH
+    sudo chown -R $username:$groupname $DOMAIN_PATH 
+}
+
+# Create .py file to setup OHS domain
+function createDomainConfigFile()
+{
+    echo "creating OHS domain configuration file ..."
+    cat <<EOF >$OHS_PATH/ohs-domain.py
+import os, sys
+setTopologyProfile('Compact')
+selectTemplate('Oracle HTTP Server (Standalone)')
+loadTemplates()
+showTemplates()
+cd('/')
+create("${OHS_COMPONENT_NAME}", 'SystemComponent')
+cd('SystemComponent/' + '${OHS_COMPONENT_NAME}')
+set('ComponentType','OHS')
+cd('/')
+cd('OHS/' + '${OHS_COMPONENT_NAME}')
+set('ListenAddress','')
+set('ListenPort', '${OHS_HTTP_PORT}')
+set('SSLListenPort', '${OHS_HTTPS_PORT}')
+cd('/')
+create('sc', 'SecurityConfiguration')
+cd('SecurityConfiguration/sc')
+set('NodeManagerUsername', "${OHS_NM_USER}")
+set('NodeManagerPasswordEncrypted', "${OHS_NM_PSWD}")
+setOption('NodeManagerType','PerDomainNodeManager')
+setOption('OverwriteDomain', 'true')
+writeDomain("${OHS_DOMAIN_PATH}")
+dumpStack()
+closeTemplate()
+exit()
+
+EOF
+}
+
+#Configuring OHS standalone domain
+function setupOHSDomain()
+{
+    createDomainConfigFile
+    sudo chown -R $username:$groupname $OHS_PATH/ohs-domain.py
+    echo "Setting up OHS standalone domain at ${OHS_DOMAIN_PATH}"
+    runuser -l oracle -c  "${INSTALL_PATH}/oracle/middleware/oracle_home/oracle_common/common/bin/wlst.sh $OHS_PATH/ohs-domain.py"
+    if [[ $?==0 ]]; 
+    then
+        echo "OHS standalone domain is configured successfully"
+    else
+        echo_stderr "OHS standalone domain is configuration failed"
+        exit 1
+    fi	
+}
+
+# Create OHS silent installation templates
+function createOHSTemplates()
+{
+    sudo cp $BASE_DIR/$OHS_FILE_NAME $OHS_PATH/$OHS_FILE_NAME
+    echo "unzipping $OHS_FILE_NAME"
+    sudo unzip -o $OHS_PATH/$OHS_FILE_NAME -d $OHS_PATH
+    export SILENT_FILES_DIR=$OHS_PATH/silent-template
+    sudo mkdir -p $SILENT_FILES_DIR
+    sudo rm -rf $OHS_PATH/silent-template/*
+    mkdir -p $INSTALL_PATH
+    create_oraInstlocTemplate
+    create_oraResponseTemplate
+    sudo chown -R $username:$groupname $OHS_PATH
+    sudo chown -R $username:$groupname $INSTALL_PATH
+}
+
+# Create OHS nodemanager as service
+function create_nodemanager_service()
+{
+    echo "Setting CrashRecoveryEnabled true at $DOMAIN_PATH/$OHS_DOMAIN_NAME/nodemanager/nodemanager.properties"
+    sed -i.bak -e 's/CrashRecoveryEnabled=false/CrashRecoveryEnabled=true/g'  $DOMAIN_PATH/$OHS_DOMAIN_NAME/nodemanager/nodemanager.properties
+    if [ $? != 0 ];
+    then
+        echo "Warning : Failed in setting option CrashRecoveryEnabled=true. Continuing without the option."
+        mv $DOMAIN_PATH/nodemanager/nodemanager.properties.bak $DOMAIN_PATH/$OHS_DOMAIN_NAME/nodemanager/nodemanager.properties
+    fi
+    sudo chown -R $username:$groupname $DOMAIN_PATH/$OHS_DOMAIN_NAME/nodemanager/nodemanager.properties*
+    echo "Creating NodeManager service"
+    cat <<EOF >/etc/systemd/system/ohs_nodemanager.service
+    [Unit]
+    Description=OHS nodemanager service
+    After=network-online.target
+    Wants=network-online.target
+    [Service]
+    Type=simple
+    WorkingDirectory="$DOMAIN_PATH/$OHS_DOMAIN_NAME"
+    ExecStart="$DOMAIN_PATH/$OHS_DOMAIN_NAME/bin/startNodeManager.sh"
+    ExecStop="$DOMAIN_PATH/$OHS_DOMAIN_NAME/bin/stopNodeManager.sh"
+    User=oracle
+    Group=oracle
+    KillMode=process
+    LimitNOFILE=65535
+    Restart=always
+    RestartSec=3
+    [Install]
+    WantedBy=multi-user.target
+EOF
+
+}
+
+# Start the nodemanager service
+function enabledAndStartNodeManagerService()
+{
+    sudo systemctl enable ohs_nodemanager
+    sudo systemctl daemon-reload
+    attempt=1
+    while [[ $attempt -lt 6 ]]
+    do
+        echo "Starting nodemanager service attempt $attempt"
+        sudo systemctl start ohs_nodemanager
+        sleep 1m
+        attempt=`expr $attempt + 1`
+        sudo systemctl status ohs_nodemanager | grep "active (running)"
+        if [[ $? == 0 ]];
+  	then
+            echo "ohs_nodemanager service started successfully"
+            break
+        fi
+        sleep 3m
+    done
+}
+
+#Create Start component script
+function createStartComponent()
+{
+    cat <<EOF > $OHS_DOMAIN_PATH/startComponent.py 
+import os, sys
+nmConnect(username='${OHS_NM_USER}',password='${OHS_NM_PSWD}',domainName='${OHS_DOMAIN_NAME}')
+status=nmServerStatus(serverName='ohs_azure',serverType='OHS')
+if status != "RUNNING":
+  nmStart(serverName='ohs_azure',serverType='OHS')
+  nmServerStatus(serverName='ohs_azure',serverType='OHS')
+else:
+  print 'OHS component ohs_azure is already running'
+EOF
+
+    sudo chown -R $username:$groupname $OHS_DOMAIN_PATH/startComponent.py
+}
+
+#Create Stop component script
+function createStopComponent()
+{
+    cat <<EOF > $OHS_DOMAIN_PATH/stopComponent.py 
+import os, sys
+nmConnect(username='${OHS_NM_USER}',password='${OHS_NM_PSWD}',domainName='${OHS_DOMAIN_NAME}')
+status=nmServerStatus(serverName='ohs_azure',serverType='OHS')
+if status != "SHUTDOWN":
+  nmKill(serverName='$OHS_COMPONENT_NAME',serverType='OHS')
+  nmServerStatus(serverName='$OHS_COMPONENT_NAME',serverType='OHS')
+else:
+  print 'OHS component ohs_azure is already SHUTDOWN'
+EOF
+
+    sudo chown -R $username:$groupname $OHS_DOMAIN_PATH/stopComponent.py
+
+}
+
+# Create OHS component as service
+function createComponentService()
+{
+    echo "Creating ohs component service"
+    cat <<EOF >/etc/systemd/system/ohs_component.service
+    [Unit]
+    Description=OHS Component service
+    After=ohs_nodemanager.service
+    Wants=ohs_nodemanager.service
+	
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    WorkingDirectory="$DOMAIN_PATH/$OHS_DOMAIN_NAME"
+    ExecStart=${INSTALL_PATH}/oracle/middleware/oracle_home/oracle_common/common/bin/wlst.sh $OHS_DOMAIN_PATH/startComponent.py
+    ExecStop=${INSTALL_PATH}/oracle/middleware/oracle_home/oracle_common/common/bin/wlst.sh $OHS_DOMAIN_PATH/stopComponent.py
+    User=oracle
+    Group=oracle
+    KillMode=process
+    LimitNOFILE=65535
+[Install]
+WantedBy=multi-user.target
+
+EOF
+
+}
+
+# Start the OHS component service
+function enableAndStartOHSServerService()
+{
+    sudo systemctl enable ohs_component
+    sudo systemctl daemon-reload
+    echo "Starting ohs component service"
+    attempt=1
+    while [[ $attempt -lt 6 ]]
+    do
+        echo "Starting ohs component service attempt $attempt"
+  	sudo systemctl start ohs_component
+  	sleep 1m
+  	attempt=`expr $attempt + 1`
+  	sudo systemctl status ohs_component | grep active
+  	if [[ $? == 0 ]];
+  	then
+  	    echo "ohs_component service started successfully"
+  	    break
+  	fi
+  	sleep 3m
+  done
+}
+
+# Query the WLS and form WLS cluster address
+function getWLSClusterAddress()
+{
+    restArgs=" -v --user ${WLS_USER}:${WLS_PASSWORD} -H X-Requested-By:MyClient -H Accept:application/json -H Content-Type:application/json"
+    echo $restArgs
+    echo curl $restArgs -X GET ${WLS_REST_URL}/domainRuntime/serverRuntimes?fields=defaultURL > out
+    curl $restArgs -X GET ${WLS_REST_URL}/domainRuntime/serverRuntimes?fields=defaultURL > out
+    if [[ $? != 0 ]];
+    then
+        echo_stderr "REST query failed for servers"
+        exit 1
+    fi
+    # Default admin URL is "defaultURL": "t3:\/\/10.0.0.6:7001" which is not required as part of cluster address
+    msString=` cat out | grep defaultURL | grep -v "7001" | cut -f3 -d"/" `
+    wlsClusterAddress=`echo $msString | sed 's/\" /,/g'`
+    export WLS_CLUSTER_ADDRESS=${wlsClusterAddress::-1}
+  
+    # Test whether servers are reachable
+    testClusterServers=$(echo ${WLS_CLUSTER_ADDRESS} | tr "," "\n")
+    for server in $testClusterServers
+    do
+        echo curl http://${server}/weblogic/ready
+        curl http://${server}/weblogic/ready
+        if [[ $? == 0 ]];
+        then
+            echo "${server} is reachable"
+        else
+            echo_stderr "Failed to get cluster address properly. Cluster address received: ${wlsClusterAddress}"
+            exit 1
+        fi
+    done
+    rm -f out
+}
+
+# Create/update mod_wl_ohs configuration file based on WebLogic Cluster address
+function create_mod_wl_ohs_conf()
+{
+    getWLSClusterAddress
+  
+    echo "Creating backup file for existing mod_wl_ohs.conf file"
+    runuser -l oracle -c  "mv $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/mod_wl_ohs.conf $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/mod_wl_ohs.conf.bkp"
+    runuser -l oracle -c  "mv $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/$OHS_COMPONENT_NAME/mod_wl_ohs.conf $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/$OHS_COMPONENT_NAME/mod_wl_ohs.conf.bkp"
+  
+    echo "Creating mod_wl_ohs.conf file as per ${WLS_CLUSTER_ADDRESS}"	
+    cat <<EOF > $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/mod_wl_ohs.conf
+    LoadModule weblogic_module   "${INSTALL_PATH}/oracle/middleware/oracle_home/ohs/modules/mod_wl_ohs.so"
+    <IfModule weblogic_module>
+      WLIOTimeoutSecs 900
+      KeepAliveSecs 290
+      FileCaching ON
+      WLSocketTimeoutSecs 15
+      DynamicServerList ON
+      WLProxySSL ON
+      WebLogicCluster ${WLS_CLUSTER_ADDRESS}
+    </IfModule>
+    <Location / >
+      SetHandler weblogic-handler
+      DynamicServerList ON
+      WLProxySSL ON
+      WebLogicCluster  ${WLS_CLUSTER_ADDRESS}
+    </Location>
+ 
+EOF
+ 
+    sudo chown -R $username:$groupname $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/mod_wl_ohs.conf
+    runuser -l oracle -c  "cp $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/mod_wl_ohs.conf $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/$OHS_COMPONENT_NAME/."
+}
+
+# Update the network rules so that OHS_HTTP_PORT and OHS_HTTPS_PORT is accessible
+function updateNetworkRules()
+{
+    # for Oracle Linux 7.3, 7.4, iptable is not running.
+    if [ -z `command -v firewall-cmd` ]; then
+       return 0
+    fi
+    sudo firewall-cmd --zone=public --add-port=$OHS_HTTP_PORT/tcp
+    sudo firewall-cmd --zone=public --add-port=$OHS_HTTPS_PORT/tcp
+    sudo firewall-cmd --runtime-to-permanent
+    sudo systemctl restart firewalld
+    sleep 30s
+}
+
+# Oracle Vault needs to be created to add JKS keystore or PKCS12 certificate for OHS
+function createOracleVault()
+{
+    runuser -l oracle -c "mkdir -p ${OHS_VAULT_PATH}"
+    runuser -l oracle -c  "${INSTALL_PATH}/oracle/middleware/oracle_home/oracle_common/bin/orapki wallet create -wallet ${OHS_VAULT_PATH} -pwd ${ORACLE_VAULT_PASSWORD} -auto_login"
+    if [[ $? == 0 ]]; 
+    then
+        echo "Successfully oracle vault is created"
+    else
+        echo_stderr "Failed to create oracle vault"
+        exit 1
+    fi	
+    ls -lt ${OHS_VAULT_PATH}
+}
+
+# Add provided certificates to Oracle vault created
+function addCertficateToOracleVault()
+{
+    ohsKeyStoreData=$(echo "$OHS_KEY_STORE_DATA" | base64 --decode)
+    ohsKeyStorePassPhrase=$(echo "$OHS_KEY_STORE_PASSPHRASE" | base64 --decode)
+
+    case "${OHS_KEY_TYPE}" in
+      "JKS")
+          echo "$ohsKeyStoreData" | base64 --decode > ${OHS_VAULT_PATH}/ohsKeystore.jks
+          sudo chown -R $username:$groupname ${OHS_VAULT_PATH}/ohsKeystore.jks
+          # Validate JKS file
+          KEY_TYPE=`keytool -list -v -keystore ${OHS_VAULT_PATH}/ohsKeystore.jks -storepass ${ohsKeyStorePassPhrase} | grep 'Keystore type:'`
+          if [[ $KEY_TYPE == *"jks"* ]]; then
+              runuser -l oracle -c  "${INSTALL_PATH}/oracle/middleware/oracle_home/oracle_common/bin/orapki wallet  jks_to_pkcs12  -wallet ${OHS_VAULT_PATH}  -pwd ${ORACLE_VAULT_PASSWORD} -keystore ${OHS_VAULT_PATH}/ohsKeystore.jks -jkspwd ${ohsKeyStorePassPhrase}"
+              if [[ $? == 0 ]]; then
+                 echo "Successfully added JKS keystore to Oracle Wallet"
+              else
+                 echo_stderr "Adding JKS keystore to Oracle Wallet failed"
+              fi
+          else
+              echo_stderr "Not a valid JKS keystore file"
+              exit 1
+          fi
+          ;;
+  	
+     "PKCS12")  	
+          echo "$ohsKeyStoreData" | base64 --decode > ${OHS_VAULT_PATH}/ohsCert.p12
+          sudo chown -R $username:$groupname ${OHS_VAULT_PATH}/ohsCert.p12
+          runuser -l oracle -c "${INSTALL_PATH}/oracle/middleware/oracle_home/oracle_common/bin/orapki wallet import_pkcs12 -wallet ${OHS_VAULT_PATH} -pwd ${ORACLE_VAULT_PASSWORD} -pkcs12file ${OHS_VAULT_PATH}/ohsCert.p12  -pkcs12pwd ${ohsKeyStorePassPhrase}"
+          if [[ $? == 0 ]]; then
+              echo "Successfully added certificate to Oracle Wallet"
+          else
+              echo_stderr "Unable to add PKCS12 certificate to Oracle Wallet"
+              exit 1
+          fi
+     	  ;;
+  esac
+}
+
+# Update ssl.conf file for SSL access and vault path
+function updateSSLConfFile()
+{
+    echo "Updating ssl.conf file for oracle vaulet"
+    runuser -l oracle -c  "cp $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/ssl.conf $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/ssl.conf.bkup"
+    runuser -l oracle -c  "cp $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/$OHS_COMPONENT_NAME/ssl.conf $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/$OHS_COMPONENT_NAME/ssl.conf.bkup"
+    runuser -l oracle -c  "sed -i 's|SSLWallet.*|SSLWallet \"${OHS_VAULT_PATH}\"|g' $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/instances/$OHS_COMPONENT_NAME/ssl.conf"
+    runuser -l oracle -c  "sed -i 's|SSLWallet.*|SSLWallet \"${OHS_VAULT_PATH}\"|g' $OHS_DOMAIN_PATH/config/fmwconfig/components/OHS/$OHS_COMPONENT_NAME/ssl.conf"
+}
+
+#Check whether service is started
+function verifyService()
+{
+    serviceName=$1
+    sudo systemctl status $serviceName | grep "active"     
+    if [[ $? != 0 ]]; 
+    then
+        echo "$serviceName is not in active state"
+        exit 1
+    fi
+    echo $serviceName is active and running
+}
+
+
+
+# Execution starts here
+
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export BASE_DIR="$(readlink -f ${CURR_DIR})"
+
+export OHS_DOMAIN_NAME=$1
+export OHS_COMPONENT_NAME=$2
+export OHS_NM_USER=$3
+export OHS_NM_PSWD=$4
+export OHS_HTTP_PORT=$5
+export OHS_HTTPS_PORT=$6
+export WLS_REST_URL=$7
+export WLS_USER=$8
+export WLS_PASSWORD=$9
+export OHS_KEY_STORE_DATA=${10}
+export OHS_KEY_STORE_PASSPHRASE=${11} 
+export ORACLE_VAULT_PASSWORD=${12}
+export OHS_KEY_TYPE=${13}
+export JDK_PATH="/u01/app/jdk"
+export JDK_VERSION="jdk1.8.0_271"
+export JAVA_HOME=$JDK_PATH/$JDK_VERSION
+export PATH=$JAVA_HOME/bin:$PATH
+export OHS_PATH="/u01/app/ohs"
+export DOMAIN_PATH="/u01/domains"
+export INSTALL_PATH="$OHS_PATH/install"
+export OHS_DOMAIN_PATH=${DOMAIN_PATH}/${OHS_DOMAIN_NAME}
+export OHS_VAULT_PATH="${DOMAIN_PATH}/ohsvault"
+export  groupname="oracle"
+export  username="oracle"
+
+
+validateInput
+setupDomainPath
+setupOHSDomain
+createStartComponent
+createStopComponent
+create_nodemanager_service
+createComponentService
+create_mod_wl_ohs_conf
+createOracleVault
+addCertficateToOracleVault
+updateSSLConfFile
+updateNetworkRules
+enabledAndStartNodeManagerService
+verifyService "ohs_nodemanager"
+enableAndStartOHSServerService
+verifyService "ohs_component"
+cleanup


### PR DESCRIPTION
Implementation for  [Issue #177:Load Balancer for Dynamic Cluster Offer](https://github.com/wls-eng/arm-oraclelinux-wls/issues/177) 

Added Oracle HTTP Server as load balancer for Dynamic Cluster.

1. Updated createUiDefinition.json for enabling Oracle HTTP Server deployment section
2. Updated mainTemplate.json  and clusterTemplate.json for supporting OHS arm template
3. Added ohsNestedTemplate which handles OHS VM and SSL setup
4. Updated setupDynamicClusterDomain.sh for handling dynamic cluster scale up/down scenarios
5. Added setupOHS.sh which does all OHS domain setup and configuration

CI/CD is working fine. Refer https://github.com/sanjaymantoor/arm-oraclelinux-wls-dynamic-cluster/actions/runs/485370826

