### PR TITLE
Add Management options for public traffic and improvements to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - addnsg
   schedule:
     - cron: "0 7 * * *"
   repository_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - addnsg
   schedule:
     - cron: "0 7 * * *"
   repository_dispatch:
@@ -513,7 +514,8 @@ jobs:
             ${{ env.testbranchName }} \
             ${{ env.managedServerPrefix }} \
             ${{ env.maxDynamicClusterSize }} \
-            ${{ env.dynamicClusterSize }}
+            ${{ env.dynamicClusterSize }} \
+            ${{ github.run_id }}${{ github.run_number }}
 
             echo "Deploy ELK Template..."
             az group deployment create \
@@ -754,3 +756,8 @@ jobs:
           inlineScript: |
             echo "delete... " $resourceGroup
             az group delete --yes --no-wait --verbose --name ${{ env.resourceGroupForDependency }}
+      - name: Delete ELK index
+        id: delete-elk-index
+        run: |
+          curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-dynamic-cluster-${{ github.run_id }}${{ github.run_number }}
+      

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .project
 .settings
 *.versionsBackup
+.classpath

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -529,7 +529,7 @@
                         "type": "Microsoft.Common.OptionsGroup",
                         "label": "Deny public traffic for managed server?",
                         "defaultValue": "Yes",
-                        "toolTip": "Select 'Yes' to deny public traffic for managed server. Configuration here for port 8001 has a higher priority than the 'Ports and port ranges to expose' in basic blade.",
+                        "toolTip": "Select 'Yes' to deny public traffic for managed server. Configuration here for port 8002 ~ 8001 + 'node number' has a higher priority than the 'Ports and port ranges to expose' in basic blade.",
                         "constraints": {
                             "allowedValues": [
                                 {

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -241,6 +241,27 @@
                             "validationMessage": "Only numbers, hyphen separated ranges of numbers, separated by commas"
                         },
                         "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
+                    },
+                    {
+                        "name": "denyPublicTrafficForAdminServer",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Deny public traffic for admin server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to deny public traffic for admin server. Configuration here for port 7001 and 7002 has a higher priority than above.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "No",
+                                    "value": false
+                                },
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                }
+                            ],
+                            "required": true
+                        },
+                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
                     }
                 ],
                 "visible": true
@@ -500,6 +521,27 @@
                             "required": true,
                             "regex": "^[a-z0-9A-Z]{1,30}$",
                             "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                        },
+                        "visible": "[steps('section_ohs').enableOHS]"
+                    },
+                    {
+                        "name": "denyPublicTrafficForManagedServer",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Deny public traffic for managed server?",
+                        "defaultValue": "Yes",
+                        "toolTip": "Select 'Yes' to deny public traffic for managed server. Configuration here for port 8001 has a higher priority than the 'Ports and port ranges to expose' in basic blade.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "No",
+                                    "value": false
+                                },
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                }
+                            ],
+                            "required": true
                         },
                         "visible": "[steps('section_ohs').enableOHS]"
                     }
@@ -1063,6 +1105,8 @@
             "authenticationType": "[basics('basicsRequired').adminPasswordOrKey.authenticationType]",
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
+            "denyPublicTrafficForAdminServer": "[basics('basicsOptional').denyPublicTrafficForAdminServer]",
+            "denyPublicTrafficForManagedServer": "[steps('section_ohs').denyPublicTrafficForManagedServer]",
             "dnsLabelPrefix": "[basics('basicsOptional').dnsLabelPrefix]",
             "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.dsConnectionURL]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]",
@@ -1075,6 +1119,7 @@
             "enableCoherence": "[bool(steps('section_coherence').enableCoherence)]",
             "enableCoherenceWebLocalStorage": "[bool(if(bool(steps('section_coherence').enableCoherence),steps('section_coherence').coherenceInfo.enableCoherenceWebLocalStorage,'false'))]",
             "enableELK": "[bool(steps('section_elk').enableELK)]",
+            "enableOHS": "[bool(steps('section_ohs').enableOHS)]",
             "jdbcDataSourceName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceName]",
             "logsToIntegrate": "[steps('section_elk').elkInfo.logsToIntegrate]",
             "managedServerPrefix": "[basics('basicsOptional').managedServerPrefix]",

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
@@ -86,6 +86,17 @@
                 "description": "Userid of Database"
             }
         },
+        "denyPublicTrafficForAdminServer": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Set 'true' to deny public inbound traffic for the admin server."
+            }
+        },
+        "denyPublicTrafficForManagedServer": {
+            "type": "bool",
+            "defaultValue": true
+        },
         "dnsLabelPrefix": {
             "defaultValue": "wls",
             "type": "string",
@@ -434,7 +445,8 @@
         "name_dbLinkedTemplateName": "dbTemplate.json",
         "name_elkLinkedTemplateName": "elkNestedTemplate.json",
         "name_coherenceTemplateName": "coherenceTemplate.json",
-        "name_ohsLinkedTemplateName": "ohsNestedTemplate.json"
+        "name_ohsLinkedTemplateName": "ohsNestedTemplate.json",
+        "name_nsgLinkedTemplateName": "nsgNestedTemplate.json"
     },
     "resources": [
         {
@@ -518,6 +530,36 @@
                     }
                 }
             }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "networkSecurityLinkedTemplate",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/', variables('name_nsgLinkedTemplateName')))]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "denyPublicTrafficForAdminServer": {
+                        "value": "[parameters('denyPublicTrafficForAdminServer')]"
+                    },
+                    "denyPublicTrafficForManagedServer": {
+                        "value": "[parameters('denyPublicTrafficForManagedServer')]"
+                    },
+                    "enableOHS": {
+                        "value": "[parameters('enableOHS')]"
+                    },
+                    "networkSecurityGroupName": {
+                        "value": "[concat(parameters('dnsLabelPrefix'), '-nsg')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'clusterLinkedTemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'ohsLinkedTemplate')]"
+            ]
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -877,6 +919,9 @@
                     "virtualNetworkName": {
                         "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.virtualNetworkName.value]"					
                     },
+                    "vmSizeSelect": {
+                        "value": "[parameters('vmSizeSelect')]"
+                    },
                     "adminRestMgmtURL": {
                         "value": "[reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminRestMgmtURL.value]"					
                     },
@@ -902,7 +947,8 @@
                 "[resourceId('Microsoft.Resources/deployments', 'dbLinkedTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'elkLinkedTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'coherenceTemplate')]",
-                "[resourceId('Microsoft.Resources/deployments', 'ohsLinkedTemplate')]"
+                "[resourceId('Microsoft.Resources/deployments', 'ohsLinkedTemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'networkSecurityLinkedTemplate')]"
             ],
             "properties": {
                 "mode": "Incremental",

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/nsgNestedTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/nsgNestedTemplate.json
@@ -1,0 +1,103 @@
+{
+	"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		"denyPublicTrafficForAdminServer": {
+			"type": "bool",
+			"defaultValue": false
+		},
+		"denyPublicTrafficForManagedServer": {
+			"type": "bool",
+			"defaultValue": false
+		},
+		"enableOHS": {
+			"type": "bool",
+			"defaultValue": false
+		},
+		"networkSecurityGroupName": {
+			"type": "string",
+			"metadata": {
+				"description": "Network Security Group name"
+			}
+		}
+	},
+	"variables": {
+		"const_subnetPrefix": "10.0.0.0/24"
+	},
+	"resources": [
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('networkSecurityGroupName'),'/','WebLogicAdminPortsAllowed')]",
+			"condition": "[not(parameters('denyPublicTrafficForAdminServer'))]",
+			"apiVersion": "${azure.apiVersion}",
+			"properties": {
+				"protocol": "TCP",
+				"sourcePortRange": "*",
+				"destinationAddressPrefix": "*",
+				"access": "Allow",
+				"priority": 210,
+				"direction": "Inbound",
+				"destinationPortRanges": [
+					"7001",
+					"7002"
+				],
+				"sourceAddressPrefix": "[variables('const_subnetPrefix')]"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('networkSecurityGroupName'),'/','WebLogicAdminPortsDenied')]",
+			"condition": "[parameters('denyPublicTrafficForAdminServer')]",
+			"apiVersion": "${azure.apiVersion}",
+			"properties": {
+				"protocol": "*",
+				"sourcePortRange": "*",
+				"destinationAddressPrefix": "*",
+				"access": "Deny",
+				"priority": 211,
+				"direction": "Inbound",
+				"destinationPortRanges": [
+					"7001",
+					"7002"
+				],
+				"sourceAddressPrefix": "Internet"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('networkSecurityGroupName'),'/','WebLogiManagedPortsAllowed')]",
+			"condition": "[and(not(parameters('denyPublicTrafficForManagedServer')), parameters('enableOHS'))]",
+			"apiVersion": "${azure.apiVersion}",
+			"properties": {
+				"protocol": "*",
+				"sourcePortRange": "*",
+				"destinationAddressPrefix": "*",
+				"access": "Deny",
+				"priority": 220,
+				"direction": "Inbound",
+				"destinationPortRanges": [
+					"8002-8999"
+				],
+				"sourceAddressPrefix": "[variables('const_subnetPrefix')]"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('networkSecurityGroupName'),'/','WebLogiManagedPortsDenied')]",
+			"condition": "[and(parameters('denyPublicTrafficForManagedServer'), parameters('enableOHS'))]",
+			"apiVersion": "${azure.apiVersion}",
+			"properties": {
+				"protocol": "*",
+				"sourcePortRange": "*",
+				"destinationAddressPrefix": "*",
+				"access": "Deny",
+				"priority": 221,
+				"direction": "Inbound",
+				"destinationPortRanges": [
+					"8002-8999"
+				],
+				"sourceAddressPrefix": "Internet"
+			}
+		}
+	]
+}

--- a/test/scripts/gen-parameters-deploy-elk.sh
+++ b/test/scripts/gen-parameters-deploy-elk.sh
@@ -15,6 +15,7 @@ testbranchName=${11}
 managedServerPrefix=${12}
 maxDynamicClusterSize=${13}
 dynamicClusterSize=${14}
+guidValue=${15}
 
 
 cat <<EOF > ${parametersPath}
@@ -54,6 +55,9 @@ cat <<EOF > ${parametersPath}
       },
       "numberOfManagedApplicationInstances": {
         "value": ${dynamicClusterSize}
+      },
+      "guidValue": {
+        "value": "${guidValue}"
       }
     }
 EOF


### PR DESCRIPTION
Add NSG deployment to manage public traffic for admin/managed servers

- Update UI to allow users to configure how they'd like to manage the public traffic
- Update mainTemplate.json to pass parameters around, add the missing 'vmSizeSelect' as I go
- Add nsgNestedTemplate.json to make the deployment. Here I depend on both 'clusterLinkedTemplate 'and 'ohsLinkedTemplate'. **And hardcode the ports to be 8002~8999 for now.**

Add ELK index cleanup step to the workflow