### PR TITLE
Exit OHS if adding JKS keystore is unsuccessful

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupOHS.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupOHS.sh
@@ -418,6 +418,7 @@ function addCertficateToOracleVault()
                  echo "Successfully added JKS keystore to Oracle Wallet"
               else
                  echo_stderr "Adding JKS keystore to Oracle Wallet failed"
+                 exit 1
               fi
           else
               echo_stderr "Not a valid JKS keystore file"


### PR DESCRIPTION
Exit OHS deployment if Oracle Wallet is unable to add supplied JKS file

Fixed [Issue# #254:Exit OHS if adding JKS is unsuccessful to Oracle Wallet](https://github.com/wls-eng/arm-oraclelinux-wls/issues/254)