### PR TITLE
Fix IP reference in dns  deployment.

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
@@ -1351,7 +1351,7 @@
                         "value": "[parameters('dnszoneResourceGroup')]"
                     },
                     "targetResources": {
-                        "value": "[if(parameters('enableOHS'), createArray(reference('clusterLinkedTemplate', '${azure.apiVersion}').outputs._adminPublicIPId.value, reference('ohsLinkedTemplate', '${azure.apiVersion}').outputs._ohsPublicIP.value), createArray(reference('clusterLinkedTemplate', '${azure.apiVersion}').outputs._adminPublicIPId.value))]"
+                        "value": "[if(parameters('enableOHS'), createArray(reference(variables('clusterTemplateRef'), '${azure.apiVersion}').outputs._adminPublicIPId.value, reference('ohsLinkedTemplate', '${azure.apiVersion}').outputs._ohsPublicIP.value), createArray(reference(variables('clusterTemplateRef'), '${azure.apiVersion}').outputs._adminPublicIPId.value))]"
                     }
                 }
 
@@ -1394,7 +1394,7 @@
         },
         "adminConsole": {
             "type": "string",
-            "value": "[if(parameters('enableCustomDNS'), format('http://{0}.{1}:7001/console',parameters('dnszoneAdminConsoleLabel'),parameters('dnszoneName')),reference('clusterLinkedTemplate','${azure.apiVersion}').outputs.adminConsole.value)]"
+            "value": "[if(parameters('enableCustomDNS'), format('http://{0}.{1}:7001/console',parameters('dnszoneAdminConsoleLabel'),parameters('dnszoneName')),reference(variables('clusterTemplateRef'),'${azure.apiVersion}').outputs.adminConsole.value)]"
         },
         "adminSecuredConsole": {
             "type": "string",

--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterCustomSSLTemplate.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterCustomSSLTemplate.json
@@ -635,6 +635,10 @@
         }
     ],
     "outputs": {
+        "_adminPublicIPId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('adminVMName'),variables('name_publicIPAddress')))]"
+        },
         "artifactsLocationPassedIn": {
             "type": "string",
             "value": "[parameters('_artifactsLocation')]"


### PR DESCRIPTION
Fixed [Incorrect reference to Cluster SSL/normal Template during deployment of dnszonesLinkedTemplate in Dynamic Cluster offer](https://github.com/wls-eng/arm-oraclelinux-wls/issues/252) 

Changes to be committed:
	modified:   arm-oraclelinux-wls-dynamic-cluster/src/main/arm/mainTemplate.json
	modified:   arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/clusterCustomSSLTemplate.json