### PR TITLE
On branch develop - Revert mistaken change that made InfoBox always v…

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -315,7 +315,7 @@
                     "icon": "None",
                     "text": "Template version ${project.version}"
                 },
-                "visible": "[bool('true')]"
+                "visible": "[bool('${template.version.visible}')]"
             },
             {
                 "name": "howToReportIssues",


### PR DESCRIPTION
…isible.

modified:   arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json

- Revert mistaken change that made InfoBox always visible.