### PR TITLE
Move job-level condition down to step level for Cleanup and Summary jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -759,17 +759,19 @@ jobs:
           git push https://$git_token@github.com/$userName/arm-oraclelinux-wls-dynamic-cluster.git -f --delete $testbranchName
 
   cleanup-az-resource:
-    if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
+    if: always()
     needs: deploy-weblogic-cluster
     runs-on: ubuntu-latest
     steps:
       - uses: azure/login@v1
+        if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
         id: azure-login
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Delete DB Resource Group
         id: delete-db-resource-group
         uses: azure/CLI@v1
+        if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
         with:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |
@@ -777,15 +779,17 @@ jobs:
             az group delete --yes --no-wait --verbose --name ${{ env.resourceGroupForDependency }}
       - name: Delete ELK index
         id: delete-elk-index
+        if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
         run: |
           curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-dynamic-cluster-${{ github.run_id }}${{ github.run_number }}
   
   summary:
     needs: deploy-weblogic-cluster
-    if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: summarize jobs
+        if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
         run: |
             workflow_jobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/wls-eng/arm-oraclelinux-wls-dynamic-cluster/actions/runs/${{ github.run_id }}/jobs)
             critical_job_num=$(echo $workflow_jobs | jq '.jobs | map(select(.name|test("^deploy-weblogic-cluster."))) | length')


### PR DESCRIPTION
[GitHub Action/needs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds)
According to the doc above, if any of the Cluster Deployment Jobs failed before, the Cleanup and Summary job will be skipped because they dependent on the Cluster jobs.
This PR moves the job-level conditions down to step level so the Cleanup and Summary job will always run.