### PR TITLE
On branch develop names of secrets are not the same as secrets.

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -703,8 +703,8 @@
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^.{6,}$",
-                                    "validationMessage": "Keypass must be at least 6 characters long."
+                                    "regex": "^[a-z0-9A-Z]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
                                 }
                             },
                             {


### PR DESCRIPTION
modified:   arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json

@zhengchang907 said:

Hi Ed, I think this is the textbox for entering the Secret Name of a passphrase, not the passphrase itself. So the regex and message here should be the same as above.
```
"regex": "^[a-z0-9A-Z]{1,30}$",
"validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
```