### PR TITLE
On branch edburns-msft-gh-298-jndi-name-validation-message-slash

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -1375,7 +1375,7 @@
                                 "constraints": {
                                     "required": "[bool(steps('section_database').enableDB)]",
                                     "regex": "^[a-z0-9A-Z/]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, and slashes (/)."
                                 },
                                 "visible": true
                             },


### PR DESCRIPTION
https://github.com/wls-eng/arm-oraclelinux-wls/issues/298

modified:   arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json

- Slashes are permitted in JNDI Name.

Signed-off-by: Ed Burns <edburns@microsoft.com>