### PR TITLE
Fixed issue#303  Exclude coherence server port for OHS WebLogic clust…

### DIFF
--- a/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupOHS.sh
+++ b/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/setupOHS.sh
@@ -316,7 +316,9 @@ function getWLSClusterAddress()
         exit 1
     fi
     # Default admin URL is "defaultURL": "t3:\/\/10.0.0.6:7001" which is not required as part of cluster address
-    msString=` cat out | grep defaultURL | grep -v "7001\|7005" | cut -f3 -d"/" `
+    # Exclude 7001 admin port, 7005 admin channel port
+    # Exclude coherence server listen port 7501
+    msString=` cat out | grep defaultURL | grep -v "7001\|7005\|7501" | cut -f3 -d"/" `
     wlsClusterAddress=`echo $msString | sed 's/\" /,/g'`
     export WLS_CLUSTER_ADDRESS=${wlsClusterAddress::-1}
   


### PR DESCRIPTION
Fixed [Dynamic offer : Exclude coherence server name/port for OHS WebLogic cluster address entry](https://github.com/wls-eng/arm-oraclelinux-wls/issues/303)

CI/CD : https://github.com/sanjaymantoor/arm-oraclelinux-wls-dynamic-cluster/actions/runs/667514052